### PR TITLE
IP-456: New Relic bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ cache:
   bundler: false
   directories:
     - vendor/bundle
+before_script:
+  - unset RACK_ENV
+  - unset RAILS_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# Head
+
+Bug fixes:
+
+- Do not load New Relic in test environments
+
 # v1.0.0 (2017-01-19)
 
-- Automatic New Relic configuration, with safeguards:w
+Features:
+
+- Automatic New Relic configuration, with safeguards
 

--- a/lib/roo_on_rails/railtie.rb
+++ b/lib/roo_on_rails/railtie.rb
@@ -28,7 +28,7 @@ module RooOnRails
       end
 
       require 'newrelic_rpm'
-      ::NewRelic::Agent.manual_start
+      ::NewRelic::Agent.manual_start unless Rails.env.test?
     end
   end
 end


### PR DESCRIPTION
This prevents New Relic from loading in test environments, as that breaks horribly.

===

Jira story [#IP-456](https://deliveroo.atlassian.net/browse/IP-456) in project *Infrastructure and Platform*:

> - Auto-configure from gem, using Railties
> - Abort if New Relic configuration vars are missing (unless in development)