### PR TITLE
IP-457: GitHub branch protection

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        enabled: yes
+        threshold: 1%
+    patch:
+      default:
+        enabled: yes
+        threshold: 5%
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment: off

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+AllCops:
+  TargetRubyVersion: 2.4
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+# Disable Metric checks for specs
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Metrics/AbcSize:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/tasks/**/*.rake'
+    - 'spec/**/*.rb'
+    - 'Gemfile'
+    - 'Guardfile'
+
+Metrics/LineLength:
+  Max: 100
+  Exclude:
+    - Gemfile
+
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'Gemfile'
     - 'Guardfile'
+    - '*.gemspec'
 
 Metrics/LineLength:
   Max: 100

--- a/lib/roo_on_rails/checks/environment.rb
+++ b/lib/roo_on_rails/checks/environment.rb
@@ -1,10 +1,12 @@
 require 'roo_on_rails/checks/env_specific'
+require 'roo_on_rails/checks/github/token'
 require 'roo_on_rails/checks/heroku/app_exists'
 require 'roo_on_rails/checks/heroku/preboot_enabled'
 
 module RooOnRails
   module Checks
     class Environment < EnvSpecific
+      requires GitHub::Token
       requires Heroku::PrebootEnabled
 
       def call

--- a/lib/roo_on_rails/checks/environment.rb
+++ b/lib/roo_on_rails/checks/environment.rb
@@ -1,12 +1,12 @@
 require 'roo_on_rails/checks/env_specific'
-require 'roo_on_rails/checks/github/token'
+require 'roo_on_rails/checks/github/branch_protection'
 require 'roo_on_rails/checks/heroku/app_exists'
 require 'roo_on_rails/checks/heroku/preboot_enabled'
 
 module RooOnRails
   module Checks
     class Environment < EnvSpecific
-      requires GitHub::Token
+      requires GitHub::BranchProtection
       requires Heroku::PrebootEnabled
 
       def call
@@ -21,4 +21,3 @@ module RooOnRails
     end
   end
 end
-

--- a/lib/roo_on_rails/checks/github/branch_protection.rb
+++ b/lib/roo_on_rails/checks/github/branch_protection.rb
@@ -1,0 +1,107 @@
+require 'roo_on_rails/checks/base'
+require 'roo_on_rails/checks/git/origin'
+require 'roo_on_rails/checks/github/token'
+
+module RooOnRails
+  module Checks
+    module GitHub
+      class BranchProtection < Base
+        requires GitHub::Token, Git::Origin
+
+        CI_CONTEXTS = %w(
+          ci/circle-ci
+          continuous-integration/travis-ci
+        ).freeze
+        private_constant :CI_CONTEXTS
+
+        def intro
+          'Checking if GitHub master branch is protected...'
+        end
+
+        def call
+          ensure_strict!
+          ensure_ci!
+          ensure_reviews!
+          ensure_no_push!
+          pass 'branch protection enabled'
+        end
+
+        def fix
+          old_status_checks = protection[:required_status_checks] || {}
+          new_status_checks = old_status_checks.merge(
+            strict: true,
+            include_admins: true,
+            contexts: (old_status_checks[:contexts] || []) | [ci_context]
+          )
+
+          old_reviews = protection[:required_pull_request_reviews] || {}
+          new_reviews = old_reviews.merge(include_admins: true)
+
+          old_restrictions = protection[:restrictions] || {}
+          new_restrictions = old_restrictions.merge(users: [], teams: [])
+
+          client.protect_branch(
+            repo,
+            branch,
+            options.merge(
+              required_status_checks: new_status_checks,
+              required_pull_request_reviews: new_reviews,
+              restrictions: new_restrictions
+            )
+          )
+        end
+
+        private
+
+        def ensure_strict!
+          status_checks = protection[:required_status_checks] || {}
+          fail! 'branch protection is not strict' unless status_checks[:strict]
+          fail! 'branch protection does not include admins' unless status_checks[:include_admins]
+        end
+
+        def ensure_ci!
+          contexts = protection.dig(:required_status_checks, :contexts) || []
+          fail! 'ci branch protection missing' unless (CI_CONTEXTS & contexts).any?
+        end
+
+        def ensure_reviews!
+          reviews = protection[:required_pull_request_reviews] || {}
+          fail! 'code reviews do not include admins' unless reviews[:include_admins]
+        end
+
+        def ensure_no_push!
+          users = protection.dig(:restrictions, :users) || []
+          teams = protection.dig(:restrictions, :teams) || []
+          fail! 'no users or teams should be allowed to push to master' if users.any? || teams.any?
+        end
+
+        def ci_context
+          if Pathname.new('.travis.yml').exist? then 'continuous-integration/travis-ci'
+          else 'ci/circle-ci'
+          end
+        end
+
+        def protection
+          client.branch_protection(repo, branch, options).to_h
+        end
+
+        def repo
+          "#{context.git_org}/#{context.git_repo}"
+        end
+
+        def branch
+          'master'
+        end
+
+        def options
+          accept = Octokit::Preview::PREVIEW_TYPES[:branch_protection]
+          accept ? { accept: accept } : {}
+        end
+
+        def client
+          context.github.api_client
+        end
+      end
+    end
+  end
+end

--- a/lib/roo_on_rails/checks/github/branch_protection.rb
+++ b/lib/roo_on_rails/checks/github/branch_protection.rb
@@ -13,9 +13,8 @@ module RooOnRails
         end
 
         def call
-          ensure_strict!
-          ensure_ci!
-          ensure_reviews!
+          ensure_status_checks!
+          ensure_code_reviews!
           ensure_no_push!
           pass 'branch protection is sufficient'
         end
@@ -34,17 +33,15 @@ module RooOnRails
 
         private
 
-        def ensure_strict!
+        def ensure_status_checks!
           status_checks = protection[:required_status_checks] || {}
           fail! 'status checks do not include admins' unless status_checks[:include_admins]
-        end
 
-        def ensure_ci!
-          contexts = protection.dig(:required_status_checks, :contexts) || []
+          contexts = status_checks[:contexts] || []
           fail! 'CI missing from status checks' unless contexts.include?(ci_context)
         end
 
-        def ensure_reviews!
+        def ensure_code_reviews!
           reviews = protection[:required_pull_request_reviews] || {}
           fail! 'code reviews do not include admins' unless reviews[:include_admins]
         end

--- a/lib/roo_on_rails/checks/github/branch_protection.rb
+++ b/lib/roo_on_rails/checks/github/branch_protection.rb
@@ -53,7 +53,6 @@ module RooOnRails
 
         def ensure_coverage_status_check!(contexts)
           return if (contexts & coverage_contexts) == coverage_contexts
-          binding.pry
           fail! 'no code coverage status checks'
         end
 

--- a/lib/roo_on_rails/checks/github/token.rb
+++ b/lib/roo_on_rails/checks/github/token.rb
@@ -1,0 +1,80 @@
+require 'roo_on_rails/checks/base'
+require 'octokit'
+require 'socket'
+
+module RooOnRails
+  module Checks
+    module GitHub
+      # Output context:
+      # - github.api_client: a connected Octokit client
+      class Token < Base
+        TOKEN_FILE = File.expand_path('~/.roo_on_rails/github-token').freeze
+        private_constant :TOKEN_FILE
+
+        def intro
+          'Obtaining GitHub access token...'
+        end
+
+        def call
+          fail! 'no token found' unless File.exist?(TOKEN_FILE)
+
+          token = File.read(TOKEN_FILE)
+
+          puts token
+          final_fail! 'No token!' if token.nil? || token.empty?
+
+          # status, token = shell.run 'heroku auth:token'
+          # fail! 'could not get a token' unless status
+
+          # context.heroku!.api_client = Octokit.connect_oauth(token.strip)
+          # pass "connected to GitHub's API"
+        end
+
+        def fix
+          token = create_access_token
+
+          FileUtils.mkpath(File.dirname(TOKEN_FILE))
+          File.write(TOKEN_FILE, token)
+        rescue Octokit::Error => e
+          final_fail! e.message
+        end
+
+        private
+
+        def create_access_token
+          result = client.create_authorization(
+            scopes: %w(repo),
+            note: token_name,
+            note_url: 'https://github.com/deliveroo/roo_on_rails',
+            headers: two_factor_headers
+          )
+          result[:token]
+        rescue Octokit::UnprocessableEntity => e
+          raise unless e.errors.any? { |err| err[:code] == 'already_exists' }
+          final_fail! "Please delete '#{token_name}' from https://github.com/settings/tokens"
+        end
+
+        def two_factor_headers
+          client.user
+          {}
+        rescue Octokit::OneTimePasswordRequired
+          otp = ask 'Enter your GitHub 2FA code:'
+          { 'X-GitHub-OTP' => otp }
+        end
+
+        def token_name
+          "Roo on Rails @ #{Socket.gethostname}"
+        end
+
+        def client
+          @client ||= begin
+            username = ask 'Enter your GitHub username:'
+            password = ask 'Enter your GitHub password (typing will be hidden):', echo: false
+            say # line break after non-echoed password
+            Octokit::Client.new(login: username, password: password)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roo_on_rails/checks/github/token.rb
+++ b/lib/roo_on_rails/checks/github/token.rb
@@ -20,11 +20,12 @@ module RooOnRails
           fail! 'no token found' unless token && !token.empty?
 
           oauth_client = Octokit::Client.new(access_token: token)
-          oauth_client.user
+          oauth_client.user # idempotent call to check access
+
           context.github!.api_client = oauth_client
           pass "connected to GitHub's API"
         rescue Octokit::Error => e
-          final_fail! "#{e.class}: #{e.message}"
+          fail! "#{e.class}: #{e.message}"
         end
 
         def fix
@@ -67,7 +68,7 @@ module RooOnRails
 
         def two_factor_headers
           @two_factor_headers ||= begin
-            basic_client.user # idempotent call just to check access
+            basic_client.user # idempotent call to check access
             {}
           rescue Octokit::OneTimePasswordRequired
             otp = ask 'Enter your GitHub 2FA code:'

--- a/lib/roo_on_rails/checks/helpers.rb
+++ b/lib/roo_on_rails/checks/helpers.rb
@@ -13,7 +13,7 @@ module RooOnRails
       def self.included(by)
         by.class_eval do
           extend Forwardable
-          delegate %i[say set_color] => :'RooOnRails::Checks::Helpers::Receiver.instance'
+          delegate %i[ask say set_color] => :'RooOnRails::Checks::Helpers::Receiver.instance'
         end
       end
 

--- a/roo_on_rails.gemspec
+++ b/roo_on_rails.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'memfs'
 end

--- a/roo_on_rails.gemspec
+++ b/roo_on_rails.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'memfs'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'codecov'
 end

--- a/roo_on_rails.gemspec
+++ b/roo_on_rails.gemspec
@@ -4,32 +4,33 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'roo_on_rails/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "roo_on_rails"
+  spec.name          = 'roo_on_rails'
   spec.version       = RooOnRails::VERSION
-  spec.authors       = ["Julien Letessier"]
-  spec.email         = ["julien.letessier@gmail.com"]
+  spec.authors       = ['Julien Letessier']
+  spec.email         = ['julien.letessier@gmail.com']
 
-  spec.summary       = %q{Scaffolding for building services}
-  spec.description   = %q{Scaffolding for building services}
+  spec.summary       = 'Scaffolding for building services'
+  spec.description   = 'Scaffolding for building services'
   spec.homepage      = 'https://github.com/deliveroo/roo_on_rails'
-  spec.license       = "MIT"
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'dotenv-rails', '~> 2.1'
   spec.add_runtime_dependency 'newrelic_rpm', '~> 3.17'
   spec.add_runtime_dependency 'rails', '~> 5.0'
   spec.add_runtime_dependency 'platform-api', '~> 0.8'
   spec.add_runtime_dependency 'hashie', '~> 3.4'
+  spec.add_runtime_dependency 'octokit'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'pry-byebug'
 end

--- a/spec/roo_on_rails/checks/github/token_spec.rb
+++ b/spec/roo_on_rails/checks/github/token_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'support/check'
+require 'roo_on_rails/checks/github/token'
+
+describe RooOnRails::Checks::GitHub::Token, type: :check do
+  describe '#call' do
+    let(:token_file) { File.expand_path('~/.roo_on_rails/github-token') }
+
+    context 'when an access token is stored locally', :memfs do
+      before do
+        MemFs.touch(token_file) && File.write(token_file, 'faketoken')
+      end
+
+      context 'and the token is valid' do
+        before do
+          allow_any_instance_of(Octokit::Client).to receive(:user)
+        end
+
+        it_expects_check_to_pass
+        it 'should set the github.api_client context property' do
+          expect { perform }.to change { context.github&.api_client }
+            .from(nil)
+            .to(kind_of(Octokit::Client))
+        end
+      end
+
+      context 'but the token is invalid' do
+        before do
+          allow_any_instance_of(Octokit::Client).to receive(:user).and_raise(Octokit::Unauthorized)
+        end
+
+        it_expects_check_to_fail
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
 require 'pry-byebug'
 require 'memfs'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,11 @@
 require 'pry-byebug'
+require 'memfs'
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-$LOAD_PATH.unshift File.expand_path("../..", __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../..', __FILE__)
+
+RSpec.configure do |config|
+  config.around(:each, memfs: true) do |example|
+    MemFs.activate { example.run }
+  end
+end


### PR DESCRIPTION
This change introduces a GitHub branch protection check for CI plus code analysis and coverage, as well as a couple of other things around code reviews and push restrictions. It also adds a task to obtain a GitHub token as a necessary prerequisite.

I did look at splitting this up into multiple tasks (i.e. one for CI, one for reviews, one for branch protection) but because the update request is a PUT rather than a PATCH you end up having to reflect back all the original configuration or you wipe it out. The end result was that there was a lot more code but it actually felt less maintainable, so I collapsed it back into a single check and refactored that for readability. I think this is the right compromise.

--

❓  I haven't written much in the way of tests for this. I can do, of course, but essentially the implementation of them all will be mocking methods on `Octokit::Client` that I'm calling and then checking the code calls then in the sequence I expect which, of course, it will because that's how I wrote it. As such, I'm somewhat unsure of the value of doing this, because really it's more that the code I've manually tested to work would be testing that I've written the mocks correctly, than that the mocks are testing code I already know works because I manually tested it. Thoughts?