### PR TITLE
BUGFIX: Branch protection with CircleCI and codecov checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# HEAD
+
+Fixes:
+
+- Use correct GitHub context name for CircleCI (#12)
+- Do not depend on sort order for Codecov GitHub contexts (#12)
+
 # v1.2.0 (2017-03-21)
 
 Features:

--- a/lib/roo_on_rails/checks/github/branch_protection.rb
+++ b/lib/roo_on_rails/checks/github/branch_protection.rb
@@ -52,7 +52,7 @@ module RooOnRails
         end
 
         def ensure_coverage_status_check!(contexts)
-          return if (contexts & coverage_contexts) == coverage_contexts
+          return if (contexts & coverage_contexts).sort == coverage_contexts.sort
           fail! 'no code coverage status checks'
         end
 
@@ -92,7 +92,7 @@ module RooOnRails
 
         def ci_context
           if Pathname.new('.travis.yml').exist? then 'continuous-integration/travis-ci'
-          else 'ci/circle-ci'
+          else 'ci/circleci'
           end
         end
 


### PR DESCRIPTION
There were a couple of issues here:

* The context for CircleCI was spelled incorrectly
* The coverage contexts could have different sort orders

This fixes both of these issues.