### PR TITLE
LT-428: Don't use Rack::SslEnforcer in test environment

### DIFF
--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -28,10 +28,13 @@ module RooOnRails
           app.config.middleware.use ::Rack::Deflater
         end
 
-        app.config.middleware.insert_before(
-          ActionDispatch::Cookies,
-          ::Rack::SslEnforcer
-        )
+        # Don't use SslEnforcer in test environment as it breaks Capybara
+        unless Rails.env.test?
+          app.config.middleware.insert_before(
+            ActionDispatch::Cookies,
+            ::Rack::SslEnforcer
+          )
+        end
       end
     end
   end

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -29,8 +29,19 @@ describe 'Http rack setup' do
       end
     end
 
-    it 'inserts rack enforcer into the middleware stack' do
-      expect(middleware).to include 'Rack::SslEnforcer'
+    context 'if RAILS_ENV is not set to "test"' do
+      it 'inserts rack enforcer into the middleware stack' do
+        expect(middleware).to include 'Rack::SslEnforcer'
+      end
+    end
+
+    context 'if RAILS_ENV is set to "test"' do
+      before { ENV['RAILS_ENV'] = 'test' }
+      after { ENV['RAILS_ENV'] = nil }
+
+      it 'does not insert rack enforcer into the middleware stack' do
+        expect(middleware).to_not include 'Rack::SslEnforcer'
+      end
     end
   end
 end


### PR DESCRIPTION
Capybara does not play nicely with Rack::SslEnforcer and the
workarounds to actually get it to do so are horrific. As test should
only be used for actual tests and not staging environments, disabling
this middleware for the test environment only seems like a pretty
reasonable step.