### PR TITLE
Allow database migrations to have a longer timeout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ Style/FrozenStringLiteralComment:
 Style/ModuleFunction:
   EnforcedStyle: extend_self
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': ()
+
 # Disable Metric checks for specs
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,8 @@ Style/ModuleFunction:
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%i': ()
+    '%i': []
+    '%w': []
 
 # Disable Metric checks for specs
 Metrics/BlockLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,11 +7,6 @@ Style/FrozenStringLiteralComment:
 Style/ModuleFunction:
   EnforcedStyle: extend_self
 
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%i': []
-    '%w': []
-
 # Disable Metric checks for specs
 Metrics/BlockLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 Features:
 
 - Sets database statement timeout to 200ms by default (#13).
+- Sets migration statement timeout to 60s by default (#16)
 
 Fixes:
 
 - Use correct GitHub context name for CircleCI (#12)
 - Do not depend on sort order for Codecov GitHub contexts (#12)
+- Do not add `Rack::SslEnforcer` middleware in test environment (#15)
 
 # v1.2.0 (2017-03-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Features:
 
 - Sets database statement timeout to 200ms by default (#13).
-- Sets migration statement timeout to 60s by default (#16)
+- Sets migration statement timeout to 10s by default (#16)
 
 Fixes:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We'll insert the following middlewares into the rails stack:
 
 The database statement timeout will be set to a low value by default. Use `DATABASE_STATEMENT_TIMEOUT` (milliseconds, default 200) to customise.
 
-For migrations (specifically the `db:migrate`, `db:migrate:down` and `db:rollback` tasks) a much higher statement timeout is set by default. Use `MIGRATION_STATEMENT_TIMEOUT` (milliseconds, default 60000) to customise.
+For migrations (specifically the `db:migrate`, `db:migrate:down` and `db:rollback` tasks) a much higher statement timeout is set by default. Use `MIGRATION_STATEMENT_TIMEOUT` (milliseconds, default 10000) to customise.
 
 _Note: This configuration is not supported in Rails 3 and will be skipped. Set statement timeouts directly in the database._
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ We'll insert the following middlewares into the rails stack:
 
 The database statement timeout will be set to a low value by default. Use `DATABASE_STATEMENT_TIMEOUT` (milliseconds, default 200) to customise.
 
-_Note: This configuration is not supported in Rails 3 and will be skipped. Set statement timeouts directly in the database._
+For migrations (specifically the `db:migrate`, `db:migrate:down` and `db:rollback` tasks) a much higher statement timeout is set by default. Use `MIGRATION_STATEMENT_TIMEOUT` (milliseconds, default 60000) to customise.
 
+_Note: This configuration is not supported in Rails 3 and will be skipped. Set statement timeouts directly in the database._
 
 ## Contributing
 

--- a/lib/roo_on_rails/tasks/db.rake
+++ b/lib/roo_on_rails/tasks/db.rake
@@ -17,10 +17,10 @@ namespace :db do
   end
 end
 
-%i[
+%i(
   db:migrate
   db:migrate:down
   db:rollback
-].each do |task|
-  Rake::Task[task].enhance(%i[db:migrate:extend_statement_timeout])
+).each do |task|
+  Rake::Task[task].enhance(%i(db:migrate:extend_statement_timeout))
 end

--- a/lib/roo_on_rails/tasks/db.rake
+++ b/lib/roo_on_rails/tasks/db.rake
@@ -10,17 +10,17 @@ namespace :db do
       if ActiveRecord::VERSION::MAJOR >= 4
         config = ActiveRecord::Base.configurations[Rails.env]
         config['variables'] ||= {}
-        config['variables']['statement_timeout'] = ENV.fetch('MIGRATION_STATEMENT_TIMEOUT', 60_000)
+        config['variables']['statement_timeout'] = ENV.fetch('MIGRATION_STATEMENT_TIMEOUT', 10_000)
         ActiveRecord::Base.establish_connection
       end
     end
   end
 end
 
-%i(
+%i[
   db:migrate
   db:migrate:down
   db:rollback
-).each do |task|
-  Rake::Task[task].enhance(%i(db:migrate:extend_statement_timeout))
+].each do |task|
+  Rake::Task[task].enhance(%i[db:migrate:extend_statement_timeout])
 end

--- a/lib/roo_on_rails/tasks/db.rake
+++ b/lib/roo_on_rails/tasks/db.rake
@@ -4,4 +4,23 @@ namespace :db do
     result = ActiveRecord::Base.connection.execute('SHOW statement_timeout').first
     puts result['statement_timeout']
   end
+
+  namespace :migrate do
+    task extend_statement_timeout: :environment do
+      if ActiveRecord::VERSION::MAJOR >= 4
+        config = ActiveRecord::Base.configurations[Rails.env]
+        config['variables'] ||= {}
+        config['variables']['statement_timeout'] = ENV.fetch('MIGRATION_STATEMENT_TIMEOUT', 60_000)
+        ActiveRecord::Base.establish_connection
+      end
+    end
+  end
+end
+
+%i[
+  db:migrate
+  db:migrate:down
+  db:rollback
+].each do |task|
+  Rake::Task[task].enhance(%i[db:migrate:extend_statement_timeout])
 end


### PR DESCRIPTION
The current 200ms statement timeout also applies itself to migrations,
which isn’t fun when you’re trying to do things like adding indexes to
existing migrations. This PR changes the statement timeout for
migrations to a much more appropriate value.