### PR TITLE
Use higher timeout for db:create rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Features:
 
 - Sets database statement timeout to 200ms by default (#13).
-- Sets migration statement timeout to 10s by default (#16)
+- Sets migration statement timeout to 10s by default (#16, #17)
 
 Fixes:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We'll insert the following middlewares into the rails stack:
 
 The database statement timeout will be set to a low value by default. Use `DATABASE_STATEMENT_TIMEOUT` (milliseconds, default 200) to customise.
 
-For migrations (specifically the `db:migrate`, `db:migrate:down` and `db:rollback` tasks) a much higher statement timeout is set by default. Use `MIGRATION_STATEMENT_TIMEOUT` (milliseconds, default 10000) to customise.
+For database creation and migration (specifically the `db:create`, `db:migrate`, `db:migrate:down` and `db:rollback` tasks) a much higher statement timeout is set by default. Use `MIGRATION_STATEMENT_TIMEOUT` (milliseconds, default 10000) to customise.
 
 _Note: This configuration is not supported in Rails 3 and will be skipped. Set statement timeouts directly in the database._
 

--- a/lib/roo_on_rails/tasks/db.rake
+++ b/lib/roo_on_rails/tasks/db.rake
@@ -18,6 +18,7 @@ namespace :db do
 end
 
 %i[
+  db:create
   db:migrate
   db:migrate:down
   db:rollback


### PR DESCRIPTION
This takes more than 200ms on my box.