### PR TITLE
Fully qualify Rack constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Fixes:
 - Use correct GitHub context name for CircleCI (#12)
 - Do not depend on sort order for Codecov GitHub contexts (#12)
 - Do not add `Rack::SslEnforcer` middleware in test environment (#15)
+- Fix for "undefined constant: RooOnRails::Rack::Timeout" (#18)
 
 # v1.2.0 (2017-03-21)
 

--- a/lib/roo_on_rails/rack/safe_timeouts.rb
+++ b/lib/roo_on_rails/rack/safe_timeouts.rb
@@ -18,7 +18,7 @@ module RooOnRails
 
       def call(env)
         @app.call(env)
-      rescue Rack::Timeout::Error, Rack::Timeout::RequestTimeoutException
+      rescue ::Rack::Timeout::Error, ::Rack::Timeout::RequestTimeoutException
         Rails.logger.warn('Clearing ActiveRecord connection cache due to timeout')
         ActiveRecord::Base.connection.clear_cache!
         raise


### PR DESCRIPTION
This error handler masks application errors because it causes Ruby to
blow up with “undefined constant RooOnRails::Rack::Timeout” when an
actual error occurs and it’s running through the exception handlers.