### PR TITLE
Use a different variable name to ActiveSupport::TaggedLogging

### DIFF
--- a/lib/roo_on_rails/context_logging.rb
+++ b/lib/roo_on_rails/context_logging.rb
@@ -48,7 +48,7 @@ module RooOnRails
 
       def current_context
         # We use our object ID here to avoid conflicting with other instances
-        thread_key = @thread_key ||= "roo_on_rails:logging_context:#{object_id}".freeze
+        thread_key = @logging_context_key ||= "roo_on_rails:logging_context:#{object_id}".freeze
         Thread.current[thread_key] ||= []
       end
 


### PR DESCRIPTION
The `@thread_key` variable name is used by
`ActiveSupport::TaggedLogging` to hold its thread key (not surprising
as that’s where I nicked most of the implementation from) but this
means if you use it together with ContextLogging then they use each
others thread keys… oops. Yeah, this is why mixing everything into the
same place is dangerous. Using a different variable name to keep things
from colliding.