### PR TITLE
Enable more heroku app names

### DIFF
--- a/lib/roo_on_rails/checks/heroku/app_exists.rb
+++ b/lib/roo_on_rails/checks/heroku/app_exists.rb
@@ -7,7 +7,7 @@ module RooOnRails
   module Checks
     module Heroku
       # Check if a corresponding app exists on Heroku (for a given environment)
-      # 
+      #
       # Input context
       # - git_repo: the name of the repository
       # - heroku.api_client: a connected PlatformAPI client
@@ -41,13 +41,17 @@ module RooOnRails
         private
 
         def name_stem
-          context.app_name_stem || context.git_repo.delete('.')
+          app_name = context.app_name_stem || context.git_repo.delete('.')
+          split_app_name = app_name.split('-')
+          split_app_name.combination(split_app_name.length - 1).map do |permutation|
+            permutation.join('-')
+          end
         end
 
         def candidates
           [
             ['deliveroo', 'roo', nil],
-            [name_stem],
+            name_stem,
             [env],
           ].tap { |a|
             a.replace a.first.product(*a[1..-1])

--- a/spec/roo_on_rails/checks/heroku/app_exists_spec.rb
+++ b/spec/roo_on_rails/checks/heroku/app_exists_spec.rb
@@ -19,7 +19,7 @@ describe RooOnRails::Checks::Heroku::AppExists, type: :check do
     let(:existing_apps) { [] }
     it_expects_check_to_fail
   end
-  
+
   context 'when multiple matching apps exist' do
     let(:existing_apps) { %w[ fubar-app-production roo-fubar-app-production ] }
     it_expects_check_to_fail
@@ -30,5 +30,12 @@ describe RooOnRails::Checks::Heroku::AppExists, type: :check do
     it_expects_check_to_pass
 
     it { expect { perform }.to change { context.heroku.app_.production }.to 'fubar-app-production' }
+  end
+
+  context 'when app name does not include all parts of the repo name' do
+    let(:existing_apps) { %w[ fubar-production ] }
+    it_expects_check_to_pass
+
+    it { expect { perform }.to change { context.heroku.app_.production }.to 'fubar-production' }
   end
 end


### PR DESCRIPTION
This PR allows more permutations of heroku app names.

This helps when a github repo name is quite long as heroku limits app names to be 30 characters.