### PR TITLE
Only load the harness if necessary

### DIFF
--- a/exe/roo_on_rails
+++ b/exe/roo_on_rails
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 require 'rubygems'
 require 'roo_on_rails/config'
-require 'roo_on_rails/harness'
-require 'roo_on_rails/sidekiq/loader'
 
 if ARGV.include? 'sidekiq'
+  require 'roo_on_rails/sidekiq/loader'
   RooOnRails::Sidekiq::Loader.run
 else
+  require 'roo_on_rails/harness'
   module RooOnRails
     Harness.new(try_fix: true, context: Config.load).run
   end

--- a/exe/roo_on_rails
+++ b/exe/roo_on_rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 require 'rubygems'
 require 'roo_on_rails/config'
 


### PR DESCRIPTION
At the moment roo_on_rails loads all the harness code even if it’s just
starting Sidekiq. That is slow and unnecessary. This change means only
the things we need to load are loaded.