### PR TITLE
Adds a newrelic:notice_deployment task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# HEAD
+
+Features:
+
+- Added `newrelic:notice_deployment` rake task (#32)
+
+Fixes:
+
+- `roo_on_rails` command only loads the checks harness if necessary (#30)
+- Upgraded outdated `platform-api` gem (#31)
+
 # v1.3.1 (2017-05-05)
 
 Features:
@@ -15,7 +26,7 @@ Features:
 - Sets database statement timeout to 200ms by default (#13).
 - Sets migration statement timeout to 10s by default (#16, #17)
 - Adds Sidekiq and Hirefire (workers) integration (#11)
-- Adds the ability to tag logs with key/value pairs (#20)
+- Adds the ability to tag logs with key/value pairs (#20, #21)
 
 Fixes:
 
@@ -23,6 +34,7 @@ Fixes:
 - Do not depend on sort order for Codecov GitHub contexts (#12)
 - Do not add `Rack::SslEnforcer` middleware in test environment (#15)
 - Fix for "undefined constant: RooOnRails::Rack::Timeout" (#18)
+- Use correct class name in Sidekiq auto-scaling metric (#22)
 
 # v1.2.0 (2017-03-21)
 
@@ -45,7 +57,7 @@ Features:
 
 # v1.0.1 (2017-01-20)
 
-Bug fixes:
+Fixes:
 
 - Do not load New Relic in test environments (#2, #3)
 

--- a/lib/roo_on_rails/tasks/newrelic.rake
+++ b/lib/roo_on_rails/tasks/newrelic.rake
@@ -1,0 +1,25 @@
+namespace :newrelic do
+  desc 'Notifies New Relic that a deployment has occurred'
+  task notice_deployment: :environment do
+    begin
+      require 'newrelic_rpm'
+      require 'new_relic/cli/command'
+
+      appname = ENV.fetch('NEW_RELIC_APP_NAME')
+
+      Rails.logger.info("Notifying New Relic of deployment to #{appname}")
+      NewRelic::Cli::Deployments.new(
+        environment: Rails.env.to_s,
+        revision: ENV.fetch('SOURCE_VERSION', 'unknown'),
+        changelog: '',
+        description: '',
+        appname: appname,
+        user: '',
+        license_key: ENV.fetch('NEW_RELIC_LICENSE_KEY')
+      ).run
+    rescue => e
+      Rails.logger.error("Failed to notify New Relic (#{e.class.name}: #{e.message})")
+      Rails.logger.info(e.backtrace.take(10).join("\n"))
+    end
+  end
+end


### PR DESCRIPTION
This can be run as part of your deploy to notify New Relic that a
deployment has occurred. The SOURCE_VERSION environment variable is
automatically set in Heroku builds.