### PR TITLE
Rails-api fixes

### DIFF
--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -17,7 +17,10 @@ module RooOnRails
           ::Rack::Timeout
         )
 
-        middleware_to_insert_before = defined?(::Rack::Head) ? ::Rack::Head : ::ActionDispatch::Cookies
+        middlewares = app.config.middleware.to_a.map { |c| c.klass.to_s }
+        middlewares.each { |p| puts p.klass.to_s }
+        
+        middleware_to_insert_before = middlewares.include?('Rack::Head') ? ::Rack::Head : ::ActionDispatch::Cookies
 
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -20,7 +20,7 @@ module RooOnRails
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.
         app.config.middleware.insert_before(
-          ActionDispatch::Cookies,
+          Rack::Head,
           RooOnRails::Rack::SafeTimeouts
         )
 

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -17,7 +17,7 @@ module RooOnRails
           ::Rack::Timeout
         )
 
-        middleware_to_insert_before = defined?('Rack::Head') ? Rack::Head : ActionDispatch::Cookies
+        middleware_to_insert_before = defined?('Rack::Head') ? ::Rack::Head : ::ActionDispatch::Cookies
 
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -20,7 +20,7 @@ module RooOnRails
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.
         app.config.middleware.insert_before(
-          Rack::Head,
+          ::Rack::Head,
           RooOnRails::Rack::SafeTimeouts
         )
 
@@ -31,7 +31,7 @@ module RooOnRails
         # Don't use SslEnforcer in test environment as it breaks Capybara
         unless Rails.env.test?
           app.config.middleware.insert_before(
-            Rack::Head,
+            ::Rack::Head,
             ::Rack::SslEnforcer
           )
         end

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -17,10 +17,7 @@ module RooOnRails
           ::Rack::Timeout
         )
 
-        middlewares = app.config.middleware.to_a.map { |c| c.klass.to_s }
-        middlewares.each { |p| puts p.klass.to_s }
-        
-        middleware_to_insert_before = middlewares.include?('Rack::Head') ? ::Rack::Head : ::ActionDispatch::Cookies
+        middleware_to_insert_before = Rails::VERSION::MAJOR < 4 ? ::ActionDispatch::Cookies : ::Rack::Head 
 
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -17,7 +17,7 @@ module RooOnRails
           ::Rack::Timeout
         )
 
-        middleware_to_insert_before = defined?('Rack::Head') ? ::Rack::Head : ::ActionDispatch::Cookies
+        middleware_to_insert_before = defined?(::Rack::Head) ? ::Rack::Head : ::ActionDispatch::Cookies
 
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -31,7 +31,7 @@ module RooOnRails
         # Don't use SslEnforcer in test environment as it breaks Capybara
         unless Rails.env.test?
           app.config.middleware.insert_before(
-            ActionDispatch::Cookies,
+            Rack::Head,
             ::Rack::SslEnforcer
           )
         end

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -17,10 +17,12 @@ module RooOnRails
           ::Rack::Timeout
         )
 
+        middleware_to_insert_before = defined?('Rack::Head') ? Rack::Head : ActionDispatch::Cookies
+
         # This needs to be inserted low in the stack, before Rails returns the
         # thread-current connection to the pool.
         app.config.middleware.insert_before(
-          ::Rack::Head,
+          middleware_to_insert_before,
           RooOnRails::Rack::SafeTimeouts
         )
 
@@ -31,7 +33,7 @@ module RooOnRails
         # Don't use SslEnforcer in test environment as it breaks Capybara
         unless Rails.env.test?
           app.config.middleware.insert_before(
-            ::Rack::Head,
+            middleware_to_insert_before,
             ::Rack::SslEnforcer
           )
         end

--- a/lib/roo_on_rails/railties/sidekiq.rb
+++ b/lib/roo_on_rails/railties/sidekiq.rb
@@ -9,10 +9,11 @@ module RooOnRails
       initializer 'roo_on_rails.sidekiq' do |app|
         require 'hirefire-resource'
         $stderr.puts 'initializer roo_on_rails.sidekiq'
-        break unless ENV.fetch('SIDEKIQ_ENABLED', 'true').to_s =~ /\A(YES|TRUE|ON|1)\Z/i
-        config_sidekiq
-        config_sidekiq_metrics
-        config_hirefire(app)
+        if ENV.fetch('SIDEKIQ_ENABLED', 'true').to_s =~ /\A(YES|TRUE|ON|1)\Z/i
+          config_sidekiq
+          config_sidekiq_metrics
+          config_hirefire(app)
+        end
       end
 
       def config_hirefire(app)

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -9,6 +9,7 @@ describe 'Http rack setup' do
     let(:middleware) { app_helper.shell_run "cd #{app_path} && rake middleware" }
 
     it 'inserts rack timeout into the middleware stack' do
+      puts middleware
       expect(middleware).to include 'Rack::Timeout'
     end
 

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -9,7 +9,7 @@ describe 'Http rack setup' do
     let(:middleware) { app_helper.shell_run "cd #{app_path} && rake middleware" }
 
     it 'inserts rack timeout into the middleware stack' do
-      puts middleware
+      binding.pry
       expect(middleware).to include 'Rack::Timeout'
     end
 

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -8,8 +8,7 @@ describe 'Http rack setup' do
   context 'When booting' do
     let(:middleware) { app_helper.shell_run "cd #{app_path} && rake middleware" }
 
-    it 'inserts rack timeout into the middleware stack' do
-      binding.pry
+    it 'inserts rack timeout into the middleware stack' do      
       expect(middleware).to include 'Rack::Timeout'
     end
 

--- a/spec/support/build_test_app.rb
+++ b/spec/support/build_test_app.rb
@@ -97,7 +97,7 @@ module ROR
         else
           "--database=#{@database}"
         end
-        
+
         options.join(' ')
       end
 

--- a/spec/support/build_test_app.rb
+++ b/spec/support/build_test_app.rb
@@ -62,8 +62,6 @@ module ROR
         shell_run "tar -C #{scaffold_dir} -cf #{scaffold_path} ."
         scaffold_dir.rmtree unless @keep_scaffold
         self
-      rescue => e
-        # binding.pry
       end
 
       def unpack_scaffold_at(path)

--- a/spec/support/build_test_app.rb
+++ b/spec/support/build_test_app.rb
@@ -63,7 +63,7 @@ module ROR
         scaffold_dir.rmtree unless @keep_scaffold
         self
       rescue => e
-        binding.pry
+        # binding.pry
       end
 
       def unpack_scaffold_at(path)


### PR DESCRIPTION
- `ActionDispatch::Cookies` is not used in api only Rails projects, so `insert_before` that uses it fails. `Rack::Head` is common in normal rails and api only and it inserts the middleware to a place it would still continue working.
- `break` to early return from Sidekiq initializer fails with `LocalJumpError` instead of trying to return early this just wraps the functions we would like to call in `if` block.