### PR TITLE
📖 Require a playbook in the repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Pre-release
+
+Features:
+
+- Adds check for a `PLAYBOOK.md` file, which should detail how to deal with issues which might occur with the service.
+
 # v1.5.0 (2017-06-19)
 
 Features:

--- a/lib/roo_on_rails/checks/documentation/playbook.rb
+++ b/lib/roo_on_rails/checks/documentation/playbook.rb
@@ -1,0 +1,23 @@
+require 'roo_on_rails/checks/base'
+
+module RooOnRails
+  module Checks
+    module Documentation
+      class Playbook < Base
+        LOCATION = 'PLAYBOOK.md'.freeze
+
+        def intro
+          'Looking for an on-call Playbook...'
+        end
+
+        def call
+          if File.exist?(LOCATION)
+            pass 'playbook found, legion on-call engineers thank you.'
+          else
+            fail! "please create a playbook at #{LOCATION}."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roo_on_rails/checks/environment.rb
+++ b/lib/roo_on_rails/checks/environment.rb
@@ -5,6 +5,7 @@ require 'roo_on_rails/checks/heroku/preboot_enabled'
 require 'roo_on_rails/checks/heroku/app_exists'
 require 'roo_on_rails/checks/sidekiq/settings'
 require 'roo_on_rails/checks/heroku/drains_metrics'
+require 'roo_on_rails/checks/documentation/playbook'
 
 module RooOnRails
   module Checks
@@ -13,6 +14,7 @@ module RooOnRails
       requires Heroku::DrainsMetrics
       requires Heroku::PrebootEnabled
       requires Sidekiq::Settings
+      requires Documentation::Playbook
 
       def call
         # nothing to do


### PR DESCRIPTION
Adds a check to the `roo_on_rails` command line app which requires a `PLAYBOOK.md` file within your repo, detailing how to deal with issues the service might have.