### PR TITLE
Google Oauth fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - unset RACK_ENV
   - unset RAILS_ENV
   - mkdir -p $PWD/tmp && sudo mount -t tmpfs -o size=1024m tmpfs $PWD/tmp
+  - gem install bundler
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# HEAD
+
+Features:
+
+- Google OAuth supported in Rails 3 and 4 (#54)
+
+Bug fixes:
+
+- Allow client apps to load middleware (#54)
+
 # v1.8.0 (2017-07-26)
 
 Bug fixes:

--- a/lib/roo_on_rails/railties/google_oauth.rb
+++ b/lib/roo_on_rails/railties/google_oauth.rb
@@ -1,4 +1,4 @@
-  require 'roo_on_rails/config'
+require 'roo_on_rails/config'
 
 module RooOnRails
   module Railties

--- a/lib/roo_on_rails/railties/google_oauth.rb
+++ b/lib/roo_on_rails/railties/google_oauth.rb
@@ -1,17 +1,13 @@
+  require 'roo_on_rails/config'
+
 module RooOnRails
   module Railties
     class GoogleOAuth < Rails::Railtie
       initializer 'roo_on_rails.google_auth.middleware' do |app|
+        $stderr.puts 'initializer roo_on_rails.google_auth'
         _if_enabled do
           _add_middleware(app)
-        end
-      end
-
-      initializer 'roo_on_rails.google_auth.routes', after: :set_routes_reloader_hook do |app|
-        _if_enabled do
           _add_routes(app)
-          # support development mode on route changes (only works in Rails 5)
-          app.reloader.to_prepare { _add_routes(app) }
         end
       end
 
@@ -19,18 +15,10 @@ module RooOnRails
 
       def _if_enabled
         return unless Config.google_auth_enabled?
-        if Rails::VERSION::MAJOR < 5
-          Rails.logger.warn 'The Google OAuth feature is not supported with Rails < 5'
-          return
-        end
-
         yield
       end
 
       def _add_middleware(app)
-        $stderr.puts 'initializer roo_on_rails.google_auth.middleware'
-
-        require 'roo_on_rails/config'
         require 'omniauth'
         require 'omniauth-google-oauth2'
         require 'active_support/core_ext/object/blank'
@@ -55,20 +43,16 @@ module RooOnRails
       end
 
       def _add_routes(app)
-        $stderr.puts 'initializer roo_on_rails.google_auth.routes'
-
         prefix = Config.google_auth_path_prefix
         ctrl   = Config.google_auth_controller
 
-        app.routes.disable_clear_and_finalize = true
-        app.routes.draw do
+        app.routes.prepend do
           get  "#{prefix}/google_oauth2",           controller: ctrl, action: 'failure'
           get  "#{prefix}/google_oauth2/callback",  controller: ctrl, action: 'create'
           post "#{prefix}/google_oauth2/callback",  controller: ctrl, action: 'create'
           get  "#{prefix}/failure",                 controller: ctrl, action: 'failure'
           get  "#{prefix}/logout",                  controller: ctrl, action: 'destroy'
         end
-        app.routes.disable_clear_and_finalize = false
       end
     end
   end

--- a/spec/integration/google_auth_spec.rb
+++ b/spec/integration/google_auth_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 require 'spec/support/run_test_app'
 
-RSpec.describe 'Google OAuth', rails_min_version:  5 do
-  run_test_app
-  before { app.wait_start }
-
+RSpec.describe 'Google OAuth' do
+  build_test_app
   after  { ENV['GOOGLE_AUTH_ENABLED'] = 'NO' }
 
   describe 'middleware' do
@@ -46,4 +44,20 @@ RSpec.describe 'Google OAuth', rails_min_version:  5 do
       end
     end
   end
+
+  describe 'other middleware' do
+    before do
+      app_helper.create_file app_path.join('config/initializers/deflater.rb'), %{
+        require 'rack/deflater'
+        Rails.application.config.middleware.use Rack::Deflater
+      }
+    end
+
+    let(:output) { app_helper.shell_run "cd #{app_path} && rake middleware" }
+
+    it 'allows for other middleware' do
+      expect(output).to include('Rack::Deflater')
+    end
+  end
+
 end


### PR DESCRIPTION
- Client apps would not load if they added any other middleware
- Using `RouteSet#prepend` happens to work in Rails 3 to 5.1