### PR TITLE
ISEC-94: Default and async Routemaster publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+Features:
+
+- Asynchronous publishing of events to Routemaster (#56)
+
 # v1.9.0 (2017-08-08)
 
 Features:

--- a/README.routemaster_client.md
+++ b/README.routemaster_client.md
@@ -8,39 +8,29 @@ It also assumes that your app has an API for the resources you want to publish l
 
 ### Setup lifecycle events for your models
 
-We will most likely want to publish lifecycle events for several models, so to write slightly less code let's create a model concern first:
-
-```ruby
-# app/models/concerns/routemaster_lifecycle_events.rb
-require 'roo_on_rails/routemaster/lifecycle_events'
-
-module RoutemasterLifecycleEvents
-  extend ActiveSupport::Concern
-  include RooOnRails::Routemaster::LifecycleEvents
-
-  included do
-    publish_lifecycle_events
-  end
-end
-```
-
-Then let's include this concern to the relevant model(s):
+You can use publish events on create, update, and destroy by including the `PublishLifecycleEvents` module:
 
 ```ruby
 # app/models/order.rb
+require 'roo_on_rails/routemaster/publish_lifecycle_events'
+
 class Order < ApplicationRecord
-  include RoutemasterLifecycleEvents
+  include RooOnRails::Routemaster::PublishLifecycleEvents
 
   # ...
 end
 ```
 
-And another one for the example:
+If you need more control over which events are published you can use the base module `LifecycleEvents` and specify them explicitly:
 
 ```ruby
 # app/models/rider.rb
+require 'roo_on_rails/routemaster/publish_lifecycle_events'
+
 class Rider < ApplicationRecord
-  include RoutemasterLifecycleEvents
+  include RooOnRails::Routemaster::LifecycleEvents
+
+  publish_lifecycle_events :create, :destroy
 
   # ...
 end
@@ -48,26 +38,31 @@ end
 
 ### Create publishers for lifecycle events
 
-We have now configured our models to publish lifecycle events to Routemaster, but it won't send anything until you have enabled publishing and created matching publishers. Let's start with creating a `BasePublisher` that we can then inherit from:
+We have now configured our models to publish lifecycle events to Routemaster, but it won't send anything until you have enabled publishing and created matching publishers. Let's start with creating an `ApplicationPublisher` that we can use as our default.
 
 ```ruby
-# app/publishers/base_publisher.rb
+# app/publishers/application_publisher.rb
 require 'roo_on_rails/routemaster/publisher'
 
-class BasePublisher < RooOnRails::Routemaster::Publisher
+class ApplicationPublisher < RooOnRails::Routemaster::Publisher
   include Rails.application.routes.url_helpers
+
+  def url
+    url_helper = :"api_#{model.class.name.underscore}_url"
+    public_send(url_helper, model.id, host: ENV.fetch('API_HOST'), protocol: 'https')
+  end
 
   # Add your method overrides here if needed
 end
 ```
 
-Then create a publisher for each model with lifecycle events enabled:
+If different behaviour is needed for specific models then you can override the defaults in their publishers:
 
 ```ruby
 # app/publishers/order_publisher.rb
-class OrderPublisher < BasePublisher
-  def url
-    api_order_url(model, host: ENV.fetch('API_HOST'), protocol: 'https')
+class OrderPublisher < ApplicationPublisher
+  def async?
+    true
   end
 end
 ```
@@ -76,9 +71,9 @@ and
 
 ```ruby
 # app/publishers/rider_publisher.rb
-class RiderPublisher < BasePublisher
-  def url
-    api_rider_url(model, host: ENV.fetch('API_HOST'), protocol: 'https')
+class RiderPublisher < ApplicationPublisher
+  def topic
+    'a_different_rider_topic'
   end
 end
 ```
@@ -96,10 +91,11 @@ PUBLISHERS = [
   RiderPublisher
 ].freeze
 
+RooOnRails::Routemaster::Publishers.register_default(ApplicationPublisher)
 PUBLISHERS.each do |publisher|
   model_class = publisher.to_s.gsub("Publisher", "").constantize
   RooOnRails::Routemaster::Publishers.register(publisher, model_class: model_class)
 end
 ```
 
-We should now be all set for our app to publish lifecycle events for `orders` and `riders` onto the event bus, so that other apps can listen to them.
+We should now be all set for our app to publish lifecycle events for all our models onto the event bus, with special behaviour for `orders` and `riders`, so that other apps can listen to them.

--- a/README.routemaster_client.md
+++ b/README.routemaster_client.md
@@ -25,7 +25,7 @@ If you need more control over which events are published you can use the base mo
 
 ```ruby
 # app/models/rider.rb
-require 'roo_on_rails/routemaster/publish_lifecycle_events'
+require 'roo_on_rails/routemaster/lifecycle_events'
 
 class Rider < ApplicationRecord
   include RooOnRails::Routemaster::LifecycleEvents

--- a/lib/roo_on_rails/routemaster/publish_lifecycle_events.rb
+++ b/lib/roo_on_rails/routemaster/publish_lifecycle_events.rb
@@ -1,0 +1,13 @@
+require 'active_support/concern'
+require 'roo_on_rails/routemaster/lifecycle_events'
+
+module RooOnRails
+  module Routemaster
+    module PublishLifecycleEvents
+      extend ActiveSupport::Concern
+      include LifecycleEvents
+
+      included(&:publish_lifecycle_events)
+    end
+  end
+end

--- a/lib/roo_on_rails/routemaster/publisher.rb
+++ b/lib/roo_on_rails/routemaster/publisher.rb
@@ -22,7 +22,7 @@ module RooOnRails
 
       def publish!
         return unless will_publish?
-        @client.send(@event, topic, url, data: stringify_keys(data))
+        @client.send(@event, topic, url, async: async?, data: stringify_keys(data))
       end
 
       def topic
@@ -31,6 +31,10 @@ module RooOnRails
 
       def url
         raise NotImplementedError
+      end
+
+      def async?
+        false
       end
 
       def data

--- a/lib/roo_on_rails/routemaster/publishers.rb
+++ b/lib/roo_on_rails/routemaster/publishers.rb
@@ -1,7 +1,12 @@
 module RooOnRails
   module Routemaster
     module Publishers
+      @default_publishers = []
       @publishers = {}
+
+      def self.register_default(publisher_class)
+        @default_publishers << publisher_class
+      end
 
       def self.register(publisher_class, model_class:)
         @publishers[model_class] ||= Set.new
@@ -9,8 +14,13 @@ module RooOnRails
       end
 
       def self.for(model, event)
-        publisher_classes = @publishers[model.class]
+        publisher_classes = @publishers[model.class] || @default_publishers
         publisher_classes.map { |c| c.new(model, event) }
+      end
+
+      def self.clear
+        @default_publishers = []
+        @publishers = {}
       end
     end
   end

--- a/spec/roo_on_rails/routemaster/publish_lifecycle_events_spec.rb
+++ b/spec/roo_on_rails/routemaster/publish_lifecycle_events_spec.rb
@@ -1,0 +1,29 @@
+require 'roo_on_rails/routemaster/publish_lifecycle_events'
+require 'roo_on_rails/routemaster/publishers'
+require 'roo_on_rails/routemaster/publisher'
+
+RSpec.describe RooOnRails::Routemaster::PublishLifecycleEvents do
+  subject do
+    Class.new do
+      @after_commit_hooks = []
+
+      def self.after_commit_hooks
+        @after_commit_hooks
+      end
+
+      def self.after_commit(*args)
+        @after_commit_hooks << args
+      end
+
+      include RooOnRails::Routemaster::PublishLifecycleEvents
+    end
+  end
+
+  it "adds three event hooks" do
+    expect(subject.after_commit_hooks).to match_array([
+      [:publish_lifecycle_event_on_create, { on: :create }],
+      [:publish_lifecycle_event_on_update, { on: :update }],
+      [:publish_lifecycle_event_on_destroy, { on: :destroy }]
+    ])
+  end
+end

--- a/spec/roo_on_rails/routemaster/publisher_spec.rb
+++ b/spec/roo_on_rails/routemaster/publisher_spec.rb
@@ -27,10 +27,13 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
         :noop,
         "test_models",
         "https://deliveroo.test/url",
-        { data: {
-          "test_key_1" => "Test value 1",
-          "test_key_2" => "Test value 2"
-        }}
+        {
+          async: false,
+          data: {
+            "test_key_1" => "Test value 1",
+            "test_key_2" => "Test value 2"
+          }
+        }
       )
       publisher.publish!
     end
@@ -41,6 +44,10 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
 
     it 'should have the correct URL' do
       expect(publisher.url).to eq("https://deliveroo.test/url")
+    end
+
+    it 'should default to publishing synchronously' do
+      expect(publisher).to_not be_async
     end
 
     it 'should have the correct event type' do

--- a/spec/roo_on_rails/routemaster/publishers_spec.rb
+++ b/spec/roo_on_rails/routemaster/publishers_spec.rb
@@ -11,6 +11,31 @@ RSpec.describe RooOnRails::Routemaster::Publishers do
   let(:event) { :noop }
 
   describe '.for' do
+    before { publishers.clear }
+
+    context 'when no publishers are registered for a model' do
+      it 'should return an empty list of publishers' do
+        expect(publishers.for(model, event)).to be_empty
+      end
+    end
+
+    context 'when a default publisher is registered' do
+      before do
+        publishers.register_default(TestPublisherA)
+      end
+
+      it 'should return an instance of the registered publisher class' do
+        expect(publishers.for(model, event).size).to eq 1
+        expect(publishers.for(model, event).first.class).to eq TestPublisherA
+      end
+      it 'should have the model set on the publisher' do
+        expect(publishers.for(model, event).first.model).to eq model
+      end
+      it 'should have the event set on the publisher' do
+        expect(publishers.for(model, event).first.event).to eq event
+      end
+    end
+
     context 'when one publisher is registered for a model' do
       before do
         publishers.register(TestPublisherA, model_class: model.class)
@@ -25,6 +50,25 @@ RSpec.describe RooOnRails::Routemaster::Publishers do
       end
       it 'should have the event set on the publisher' do
         expect(publishers.for(model, event).first.event).to eq event
+      end
+    end
+
+    context 'when multiple default publishers are registered' do
+      before do
+        publishers.register_default(TestPublisherA)
+        publishers.register_default(TestPublisherB)
+      end
+
+      it 'should return an instance of each registered publisher class' do
+        expect(publishers.for(model, event).size).to eq 2
+        expect(publishers.for(model, event).first.class).to eq TestPublisherA
+        expect(publishers.for(model, event).last.class).to eq TestPublisherB
+      end
+      it 'should have the model set on the publishers' do
+        expect(publishers.for(model, event).map(&:model).uniq).to eq [model]
+      end
+      it 'should have the event set on the publishers' do
+        expect(publishers.for(model, event).map(&:event).uniq).to eq [event]
       end
     end
 
@@ -44,6 +88,24 @@ RSpec.describe RooOnRails::Routemaster::Publishers do
       end
       it 'should have the event set on the publishers' do
         expect(publishers.for(model, event).map(&:event).uniq).to eq [event]
+      end
+    end
+
+    context 'when both a default publisher and a model-specific publisher are registered' do
+      before do
+        publishers.register_default(TestPublisherA)
+        publishers.register(TestPublisherB, model_class: model.class)
+      end
+
+      it 'should return an instance of only the model-specific publisher' do
+        expect(publishers.for(model, event).size).to eq 1
+        expect(publishers.for(model, event).last.class).to eq TestPublisherB
+      end
+      it 'should have the model set on the publisher' do
+        expect(publishers.for(model, event).first.model).to eq model
+      end
+      it 'should have the event set on the publisher' do
+        expect(publishers.for(model, event).first.event).to eq event
       end
     end
   end


### PR DESCRIPTION
While integrating the publishing library I found that:

* It was missing async publishing (and in my case linking availability
of the service to Routemaster by putting it on a hot path, which is
bad).

* I was repeating a bunch of boilerplate from the docs which could be
made into code that doesn’t need to be repeated.

As such, this adds async publishing as an option. This is at the
publisher level rather than in the model, because it’s possible you
might want multiple publishers for a model and one might be sync with
the other async.

It also adds the ability to register default publishers because most of
the time they’ll be the same and you can infer the URL in a common
publisher. I’ve changed the name to `ApplicationPublisher` in the docs
rather than `BasePublisher` to fit in with the general Rails naming
scheme.