### PR TITLE
SETI-483: roo_on_rails aborts on the first failed check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# HEAD
+
+Features:
+
+- The `roo_on_rails` test harness now defaults to not fixing issues, and has extra
+  `--env` and `--fix` flags
+- All checks will now run regardless of previous failure to avoid
+  back-and-forthing (#57)
+
+
 # v1.10.0 (2017-08-11)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ If you then want to enable the publishing of events onto the event bus, you need
 Run the following from your app's top-level directory:
 
 ```
-bundle exec roo_on_rails
+roo_on_rails harness
 ```
 
 That command will sequentially run a number of checks. For it to run successfully, you will need:
@@ -223,17 +223,18 @@ That command will sequentially run a number of checks. For it to run successfull
 - a GitHub API token that can read your GitHub repository's settings placed in `~/.roo_on_rails/github-token`
 - the Heroku toolbelt installed and logged in
 - admin privileges on the `roo-dd-bridge-production` (this will be addressed eventually)
-- checks are run sequentially for staging and then for production. The process halts at any non-fixable failing check. To process only specific environments, you can set a config variable while running the command, like so:
+
+The command can automatically fix most of the failing checks automatically;
+simply run it with the `--fix` flag:
 
 ```
-# the default behaviour:
-ROO_ON_RAILS_ENVIRONMENTS=staging,production bundle exec roo_on_rails
+roo_on_rails harness --fix
+```
 
-# run checks only on staging:
-ROO_ON_RAILS_ENVIRONMENTS=staging bundle exec roo_on_rails
+To run checks for only one environment, use the `--env` flag:
 
-# run checks only on production:
-ROO_ON_RAILS_ENVIRONMENTS=production bundle exec roo_on_rails
+```
+roo_on_rails harness --env staging
 ```
 
 

--- a/exe/roo_on_rails
+++ b/exe/roo_on_rails
@@ -70,7 +70,7 @@ module RooOnRails
             _options[:fix] = true
           end
 
-          o.on('-e', '--environment', 'Application environments to check') do |v|
+          o.on('-e', '--env', 'Application environments to check (comma-separated)') do |v|
             _options[:env] = v
           end
         end

--- a/exe/roo_on_rails
+++ b/exe/roo_on_rails
@@ -3,12 +3,104 @@
 require 'rubygems'
 require 'roo_on_rails/config'
 
-if ARGV.include? 'sidekiq'
-  require 'roo_on_rails/sidekiq/loader'
-  RooOnRails::Sidekiq::Loader.run
-else
-  require 'roo_on_rails/harness'
-  module RooOnRails
-    Harness.new(try_fix: true, context: Config.load).run
+
+module RooOnRails
+  module CLI
+    class Base
+      attr_reader :argv
+
+      def initialize(argv)
+        @argv = argv
+      end
+
+      def usage
+        raise NotImplementedError
+      end
+
+      protected
+
+      def _log(message)
+        $stderr.puts message
+      end
+
+      def _assert_argv(enum)
+        return if enum.include?(argv.length)
+        $stderr.puts enum.inspect
+        $stderr.puts argv.inspect
+        _log 'Wrong number of arguments.'
+        _log "Usage: #{usage}"
+        exit 1
+      end
+    end
+
+    class Sidekiq < Base
+      def usage
+        'roo_on_rails sidekiq'
+      end
+
+      def run
+        _assert_argv(0..0)
+        require 'roo_on_rails/sidekiq/loader'
+        RooOnRails::Sidekiq::Loader.run
+      end
+    end
+
+    class Harness < Base
+      def usage
+        'roo_on_rails harness [-f|--fix]'
+      end
+
+      def run
+        _parser.parse!(argv)
+        _assert_argv(0..0)
+        require 'roo_on_rails/harness'
+        RooOnRails::Harness.new(try_fix: _options[:fix], context: Config.load).run
+      end
+
+      private
+
+      def _options
+        @options ||= { fix: false, env: nil }
+      end
+
+      def _parser
+        require 'optionparser'
+
+        OptionParser.new do |o|
+          o.banner = usage
+
+          o.on('-f', '--fix', 'Attempt to fix failed checks') do |v|
+            _options[:fix] = true
+          end
+
+          o.on('-e', '--environment', 'Application environments to check') do |v|
+            _options[:env] = v
+          end
+        end
+      end
+    end
+
+    class Toplevel < Base
+      def usage
+        'roo_on_rails [sidekiq|harness] [options]'
+      end
+
+      def run
+        case argv.first
+        when 'sidekiq' then
+          argv.shift
+          Sidekiq.new(argv).run
+        when 'harness', nil then
+          argv.shift
+          Harness.new(argv).run
+        else
+          _log 'Incorrect arguments.'
+          _log "Usage: #{usage}"
+          exit 1
+        end
+      end
+    end
   end
 end
+
+RooOnRails::CLI::Toplevel.new(ARGV).run

--- a/exe/roo_on_rails
+++ b/exe/roo_on_rails
@@ -22,10 +22,8 @@ module RooOnRails
         $stderr.puts message
       end
 
-      def _assert_argv(enum)
-        return if enum.include?(argv.length)
-        $stderr.puts enum.inspect
-        $stderr.puts argv.inspect
+      def _assert_argv_length(range)
+        return if range.include?(argv.length)
         _log 'Wrong number of arguments.'
         _log "Usage: #{usage}"
         exit 1
@@ -38,7 +36,7 @@ module RooOnRails
       end
 
       def run
-        _assert_argv(0..0)
+        _assert_argv_length(0..0)
         require 'roo_on_rails/sidekiq/loader'
         RooOnRails::Sidekiq::Loader.run
       end
@@ -51,7 +49,7 @@ module RooOnRails
 
       def run
         _parser.parse!(argv)
-        _assert_argv(0..0)
+        _assert_argv_length(0..0)
         require 'roo_on_rails/harness'
         RooOnRails::Harness.new(try_fix: _options[:fix], context: Config.load).run
       end

--- a/exe/roo_on_rails
+++ b/exe/roo_on_rails
@@ -3,7 +3,6 @@
 require 'rubygems'
 require 'roo_on_rails/config'
 
-
 module RooOnRails
   module CLI
     class Base
@@ -69,7 +68,7 @@ module RooOnRails
         OptionParser.new do |o|
           o.banner = usage
 
-          o.on('-f', '--fix', 'Attempt to fix failed checks') do |v|
+          o.on('-f', '--fix', 'Attempt to fix failed checks') do
             _options[:fix] = true
           end
 

--- a/lib/roo_on_rails/checks/base.rb
+++ b/lib/roo_on_rails/checks/base.rb
@@ -36,7 +36,7 @@ module RooOnRails
 
         begin
           call
-        rescue Failure => e
+        rescue Failure
           return false unless @fix
           say "\t· attempting to fix", %i[yellow]
           fix
@@ -99,7 +99,7 @@ module RooOnRails
         context.deps ||= {}
         deps.map { |dep|
           sig = dep.signature.join('/')
-          if context.deps.has_key?(sig)
+          if context.deps.key?(sig)
             context.deps[sig]
           else
             context.deps[sig] = dep.run

--- a/lib/roo_on_rails/checks/base.rb
+++ b/lib/roo_on_rails/checks/base.rb
@@ -24,18 +24,30 @@ module RooOnRails
       end
 
       def run
-        resolve dependencies
-        return true if @dry_run
+        dependency_status = resolve dependencies
+
         say intro
-        call
+        unless dependency_status
+          final_fail! 'Unmet dependencies.'
+          return
+        end
+
+        return true if @dry_run
+
+        begin
+          call
+        rescue Failure => e
+          return false unless @fix
+          say "\t· attempting to fix", %i[yellow]
+          fix
+          @fix = false
+          say "\t· re-checking", %i[yellow]
+          retry
+        end
+
         true
-      rescue Failure => e
-        raise if e === FinalFailure
-        raise unless @fix
-        say "\t· attempting to fix", %i[yellow]
-        fix
-        say "\t· re-checking", %i[yellow]
-        call
+      rescue FinalFailure
+        false
       end
 
       protected
@@ -44,7 +56,7 @@ module RooOnRails
 
       # Returns prerequisite checks. Can be overriden.
       def dependencies
-        self.class.requires.map { |k|
+        @dependencies ||= self.class.requires.map { |k|
           k.new(fix: @fix, context: @context, shell: @shell, **@options)
         }
       end
@@ -54,11 +66,11 @@ module RooOnRails
       end
 
       def call
-        fail! "this check wasn't implemented"
+        final_fail! "this check wasn't implemented"
       end
 
       def fix
-        fail! "can't fix this on my own"
+        final_fail! "can't fix this on my own"
       end
 
       def pass(msg)
@@ -84,10 +96,15 @@ module RooOnRails
 
       # Run each dependency, then mark them as run.
       def resolve(deps)
-        deps.each do |dep|
-          context.deps ||= {}
-          context.deps[dep.signature.join('/')] ||= dep.run
-        end
+        context.deps ||= {}
+        deps.map { |dep|
+          sig = dep.signature.join('/')
+          if context.deps.has_key?(sig)
+            context.deps[sig]
+          else
+            context.deps[sig] = dep.run
+          end
+        }.to_a.all?
       end
     end
   end

--- a/lib/roo_on_rails/checks/documentation/playbook.rb
+++ b/lib/roo_on_rails/checks/documentation/playbook.rb
@@ -14,7 +14,7 @@ module RooOnRails
         def call
           fail! "no playbook at #{LOCATION}." if playbook_missing?
           final_fail! 'playbook still contains FIXME template sections' if playbook_unfinished?
-          pass  'playbook found, legion on-call engineers thank you.'
+          pass 'playbook found, legion on-call engineers thank you.'
         end
 
         def fix

--- a/lib/roo_on_rails/checks/documentation/playbook.rb
+++ b/lib/roo_on_rails/checks/documentation/playbook.rb
@@ -13,15 +13,11 @@ module RooOnRails
 
         def call
           fail! "no playbook at #{LOCATION}." if playbook_missing?
-          fail! 'playbook still contains FIXME template sections' if playbook_unfinished?
+          final_fail! 'playbook still contains FIXME template sections' if playbook_unfinished?
           pass  'playbook found, legion on-call engineers thank you.'
         end
 
         def fix
-          if !playbook_missing? && playbook_unfinished?
-            fail! 'please add detail to your playbook, removing FIXME sections'
-          end
-
           FileUtils.cp(
             File.join(__dir__, 'playbook_template.md'),
             LOCATION

--- a/lib/roo_on_rails/checks/environment.rb
+++ b/lib/roo_on_rails/checks/environment.rb
@@ -1,5 +1,4 @@
 require 'roo_on_rails/checks/env_specific'
-require 'roo_on_rails/checks/github/branch_protection'
 require 'roo_on_rails/checks/heroku/app_exists'
 require 'roo_on_rails/checks/heroku/preboot_enabled'
 require 'roo_on_rails/checks/heroku/app_exists'
@@ -9,19 +8,18 @@ require 'roo_on_rails/checks/papertrail/all'
 module RooOnRails
   module Checks
     class Environment < EnvSpecific
-      requires GitHub::BranchProtection
       requires Heroku::DrainsMetrics
       requires Heroku::PrebootEnabled
       requires Papertrail::All
 
       def call
-        # nothing to do
+        pass 'all good'
       end
 
       protected
 
       def intro
-        "Validated #{bold @env} environment"
+        "Validating #{bold @env} environment"
       end
     end
   end

--- a/lib/roo_on_rails/checks/environment_independent.rb
+++ b/lib/roo_on_rails/checks/environment_independent.rb
@@ -1,0 +1,25 @@
+require 'roo_on_rails/checks/base'
+require 'roo_on_rails/checks/github/branch_protection'
+require 'roo_on_rails/checks/sidekiq/settings'
+require 'roo_on_rails/checks/documentation/playbook'
+
+module RooOnRails
+  module Checks
+    class EnvironmentIndependent < Base
+      requires GitHub::BranchProtection
+      requires Documentation::Playbook
+      requires Sidekiq::Settings
+
+      def intro
+        "Validating environment-independent setup"
+      end
+
+      def call
+        say "All good", :green
+      end
+
+      protected
+
+    end
+  end
+end

--- a/lib/roo_on_rails/checks/environment_independent.rb
+++ b/lib/roo_on_rails/checks/environment_independent.rb
@@ -11,15 +11,12 @@ module RooOnRails
       requires Sidekiq::Settings
 
       def intro
-        "Validating environment-independent setup"
+        'Validating environment-independent setup'
       end
 
       def call
-        say "All good", :green
+        say 'All good', :green
       end
-
-      protected
-
     end
   end
 end

--- a/lib/roo_on_rails/checks/heroku/drains_metrics.rb
+++ b/lib/roo_on_rails/checks/heroku/drains_metrics.rb
@@ -18,7 +18,7 @@ module RooOnRails
         requires Heroku::AppExists, MetricsBridgeConfigured
 
         def intro
-          "Checking for metrics drain..."
+          'Checking for metrics drain...'
         end
 
         def call

--- a/lib/roo_on_rails/checks/heroku/drains_metrics.rb
+++ b/lib/roo_on_rails/checks/heroku/drains_metrics.rb
@@ -18,7 +18,7 @@ module RooOnRails
         requires Heroku::AppExists, MetricsBridgeConfigured
 
         def intro
-          "Checking for metrics drain on #{bold app_name}"
+          "Checking for metrics drain..."
         end
 
         def call
@@ -28,7 +28,7 @@ module RooOnRails
 
           fail! 'No matching drain found' if url.nil?
           final_fail! 'Misconfigured drain found' if url != drain_uri
-          pass 'Drain is connected'
+          pass "Drain is connected to #{bold app_name}"
         end
 
         private

--- a/lib/roo_on_rails/checks/heroku/metrics_bridge_configured.rb
+++ b/lib/roo_on_rails/checks/heroku/metrics_bridge_configured.rb
@@ -22,7 +22,7 @@ module RooOnRails
         BRIDGE_APP = 'roo-dd-bridge-production'.freeze
 
         def intro
-          "Checking whether metrics bridge is configured..."
+          'Checking whether metrics bridge is configured...'
         end
 
         def call

--- a/lib/roo_on_rails/checks/heroku/metrics_bridge_configured.rb
+++ b/lib/roo_on_rails/checks/heroku/metrics_bridge_configured.rb
@@ -22,7 +22,7 @@ module RooOnRails
         BRIDGE_APP = 'roo-dd-bridge-production'.freeze
 
         def intro
-          "Checking whether metrics bridge is configured for #{bold app_name}"
+          "Checking whether metrics bridge is configured..."
         end
 
         def call
@@ -33,7 +33,7 @@ module RooOnRails
           fail! 'Bridge lacks credentials for this app' unless config[token_var]
           fail! 'Bridge lacks tags for this app'        unless config[tags_var]
 
-          pass 'Bridge is configured'
+          pass "Bridge is configured for #{bold app_name}"
           context.heroku.metric_bridge_token![env] = config[token_var]
         end
 

--- a/lib/roo_on_rails/checks/heroku/preboot_enabled.rb
+++ b/lib/roo_on_rails/checks/heroku/preboot_enabled.rb
@@ -12,15 +12,15 @@ module RooOnRails
         requires Git::Origin, Heroku::AppExists
 
         def intro
-          "Checking preboot status on #{bold app_name}"
+          "Checking preboot status..."
         end
 
         def call
           status = client.app_feature.info(app_name, 'preboot')
           if status['enabled']
-            pass 'preboot enabled'
+            pass "preboot enabled on #{bold app_name}"
           else
-            fail! 'preboot disabled'
+            fail! "preboot disabled on #{bold app_name}"
           end
         end
 

--- a/lib/roo_on_rails/checks/heroku/preboot_enabled.rb
+++ b/lib/roo_on_rails/checks/heroku/preboot_enabled.rb
@@ -12,7 +12,7 @@ module RooOnRails
         requires Git::Origin, Heroku::AppExists
 
         def intro
-          "Checking preboot status..."
+          'Checking preboot status...'
         end
 
         def call

--- a/lib/roo_on_rails/checks/papertrail/drain_exists.rb
+++ b/lib/roo_on_rails/checks/papertrail/drain_exists.rb
@@ -22,20 +22,20 @@ module RooOnRails
         requires LogDestinationExists
 
         def intro
-          "Checking for Papertrail drain on #{bold app_name}..."
+          "Checking for Papertrail drain..."
         end
 
         def call
           # find the PT drain
           data = client.log_drain.list(app_name).
                  select { |h| h['url'] =~ /papertrailapp/ }
-          fail! 'no Papertrail drain found' if data.empty?
-          fail! 'multiple Papertrail drains found' if data.length > 1
+          fail! "no Papertrail drain found on #{bold app_name}" if data.empty?
+          fail! "multiple Papertrail drains found on #{bold app_name}" if data.length > 1
 
           data = data.first
           fail! "app is draining to #{data['url']} instead of #{papertrail_url}" if data['url'] != papertrail_url
 
-          pass "found drain setup with token #{data['token']}"
+          pass "found drain setup with token #{data['token']} on #{bold app_name}"
           context.papertrail.system_name![env] = data['token']
         end
 

--- a/lib/roo_on_rails/checks/papertrail/drain_exists.rb
+++ b/lib/roo_on_rails/checks/papertrail/drain_exists.rb
@@ -22,7 +22,7 @@ module RooOnRails
         requires LogDestinationExists
 
         def intro
-          "Checking for Papertrail drain..."
+          'Checking for Papertrail drain...'
         end
 
         def call

--- a/lib/roo_on_rails/checks/papertrail/system_exists.rb
+++ b/lib/roo_on_rails/checks/papertrail/system_exists.rb
@@ -26,7 +26,7 @@ module RooOnRails
         requires LogDestinationExists
 
         def intro
-          "Checking that the app is logging to Papertrail..."
+          'Checking that the app is logging to Papertrail...'
         end
 
         def call

--- a/lib/roo_on_rails/checks/papertrail/system_exists.rb
+++ b/lib/roo_on_rails/checks/papertrail/system_exists.rb
@@ -26,14 +26,14 @@ module RooOnRails
         requires LogDestinationExists
 
         def intro
-          "Checking that #{bold app_name} is logging to Papertrail"
+          "Checking that the app is logging to Papertrail..."
         end
 
         def call
           data = context.papertrail.client.list_systems.find { |h|
             h['hostname'] == system_token
           }
-          fail! "no system with token '#{system_token}' found" if data.nil?
+          fail! "no system with token '#{system_token}' found on #{bold app_name}" if data.nil?
 
           if data.syslog.hostname != context.papertrail.dest.host ||
              data.syslog.port != context.papertrail.dest.port

--- a/lib/roo_on_rails/checks/papertrail/system_named.rb
+++ b/lib/roo_on_rails/checks/papertrail/system_named.rb
@@ -21,7 +21,7 @@ module RooOnRails
         requires SystemExists
 
         def intro
-          "Checking that #{bold app_name} is named in Papertrail"
+          "Checking that the app is named in Papertrail"
         end
 
         def call

--- a/lib/roo_on_rails/checks/papertrail/system_named.rb
+++ b/lib/roo_on_rails/checks/papertrail/system_named.rb
@@ -21,7 +21,7 @@ module RooOnRails
         requires SystemExists
 
         def intro
-          "Checking that the app is named in Papertrail"
+          'Checking that the app is named in Papertrail'
         end
 
         def call

--- a/lib/roo_on_rails/checks/sidekiq/settings.rb
+++ b/lib/roo_on_rails/checks/sidekiq/settings.rb
@@ -15,7 +15,7 @@ module RooOnRails
           if File.exist?('config/sidekiq.yml')
             message = [
               'Custom Sidekiq settings found.',
-              '  Please see the Roo On Rails readme for more information.'
+              'Please see the Roo On Rails readme for more information.'
             ].join("\n")
 
             fail! message

--- a/lib/roo_on_rails/checks/sidekiq/sidekiq.rb
+++ b/lib/roo_on_rails/checks/sidekiq/sidekiq.rb
@@ -16,6 +16,7 @@ module RooOnRails
             return
           end
           check_for_procfile
+          pass 'found valid Procfile'
         end
 
         def fix

--- a/lib/roo_on_rails/harness.rb
+++ b/lib/roo_on_rails/harness.rb
@@ -9,10 +9,11 @@ module RooOnRails
   class Harness
     include Thor::Shell
 
-    def initialize(try_fix: false, context: Hashie::Mash.new, dry_run: false)
+    def initialize(try_fix: false, environments: nil, context: Hashie::Mash.new, dry_run: false)
       @try_fix = try_fix
       @context = context
       @dry_run = dry_run
+      @environments = environments
     end
 
     def run
@@ -37,7 +38,8 @@ module RooOnRails
     private
 
     def environments
-      ENV.fetch('ROO_ON_RAILS_ENVIRONMENTS', 'staging,production').split(',')
+      as_string = @environments || ENV.fetch('ROO_ON_RAILS_ENVIRONMENTS', 'staging,production')
+      as_string.split(',')
     end
   end
 end


### PR DESCRIPTION
- Cleans up the master CLI, to support `roo_on_rails [sidekiq|harness]` subcommands
- Default to not fixing harness issue. Adds a `--fix` flag.
- Adds a `--env` flag to only run checks for a given environment (replaces the `ROO_ON_RAILS_ENVIRONMENTS` variable)
- Runs all checks even when one fails.

This last one is the masthead feature. Example run on `logistics-dashboard`:

![image](https://user-images.githubusercontent.com/231698/29413547-06755d9e-835d-11e7-8c54-a156bb0fba7b.png)

...

![image](https://user-images.githubusercontent.com/231698/29413568-163c3702-835d-11e7-9ef9-177bb5bf1826.png)

(previously, this would have aborted at the first failed check)

===

Jira story [#SETI-483](https://deliveroo.atlassian.net/browse/SETI-483) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> The roo_on_rails command aborts on the first failed check, requiring some back-and-worth when multiple things need to be fixed.
> 
> ## What
> 
> Continue after a failed check, and mention when checks get skipped because dependencies are not met.