### PR TITLE
SETI-482: Error message when missing roo-dd-bridge permissions is confusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
   `--env` and `--fix` flags
 - All checks will now run regardless of previous failure to avoid
   back-and-forthing (#57)
+- Friendlier error message when facing Heroku permission errors (#58)
 
 
 # v1.10.0 (2017-08-11)

--- a/lib/roo_on_rails/checks/heroku/metrics_bridge_configured.rb
+++ b/lib/roo_on_rails/checks/heroku/metrics_bridge_configured.rb
@@ -48,10 +48,14 @@ module RooOnRails
             token_var    => SecureRandom.hex(16),
             app_list_var => app_list.to_a.join(',')
           )
+        rescue Excon::Error::Forbidden
+          fail! "You are missing 'operate' permissions for #{bold BRIDGE_APP}"
         end
 
         def current_config
           client.config_var.info_for_app(BRIDGE_APP)
+        rescue Excon::Error::Forbidden
+          fail! "You are missing 'deploy' permissions for #{bold BRIDGE_APP}"
         end
 
         def app_list_var

--- a/spec/roo_on_rails/checks/heroku/metrics_bridge_configured_spec.rb
+++ b/spec/roo_on_rails/checks/heroku/metrics_bridge_configured_spec.rb
@@ -48,5 +48,14 @@ describe RooOnRails::Checks::Heroku::MetricsBridgeConfigured, type: :check do
       before { bridge_app_config.delete 'FOOBAR-PRODUCTION_TAGS' }
       it_expects_check_to_fail
     end
+
+    context 'when the user lacks permissions' do
+      before do
+        allow(client).to receive_message_chain(:config_var, :info_for_app).
+          and_raise(Excon::Error::Forbidden.new('oy vey'))
+      end
+
+      it_expects_check_to_fail
+    end
   end
 end


### PR DESCRIPTION
Instead of printing

```
Excon::Error::Forbidden: Expected([200, 201, 202, 204, 206, 304]) <=> Actual(403 Forbidden)
```

when trying to set up the metrics bridge for an app, prints

```
You are missing 'operate' permissions for roo_dd_bridge_production
```

===

Jira story [#SETI-482](https://deliveroo.atlassian.net/browse/SETI-482) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> When the user lacks permissions to change the configuration on `roo-dd-bridge-production`, the error message is (e.g.)
> 
> {code}
> Checking whether metrics bridge is configured for direct-payments-staging
> bundler: failed to load command: roo_on_rails (/Users/katewilkinson/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/bin/roo_on_rails)
> Excon::Error::Forbidden: Expected([200, 201, 202, 204, 206, 304]) <=> Actual(403 Forbidden)
> {code}
> 
> ## What
> 
> Provide a nicer error message, pointing to resolution.
> 
