### PR TITLE
Use model names not classes to avoid issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
   back-and-forthing (#57)
 - Friendlier error message when facing Heroku permission errors (#58)
 - Replaces the Rails logger with a structured logger (#60)
+- Bugfix for supporting non-default publishers after a `reload!` in the rails console (#62)
 
 
 # v1.10.0 (2017-08-11)

--- a/lib/roo_on_rails/routemaster/publishers.rb
+++ b/lib/roo_on_rails/routemaster/publishers.rb
@@ -9,12 +9,12 @@ module RooOnRails
       end
 
       def self.register(publisher_class, model_class:)
-        @publishers[model_class] ||= Set.new
-        @publishers[model_class] << publisher_class
+        @publishers[model_class.name] ||= Set.new
+        @publishers[model_class.name] << publisher_class
       end
 
       def self.for(model, event)
-        publisher_classes = @publishers[model.class] || @default_publishers
+        publisher_classes = @publishers[model.class.name] || @default_publishers
         publisher_classes.map { |c| c.new(model, event) }
       end
 


### PR DESCRIPTION
I was having some trouble with Roo On Rails using an incorrect publisher, demonstrated with this pseudo-irb session, so I've created a PR here to use the names of the model classes, rather than the classes. I've not investigated why the objects would be different, but it's likely because of a `reload!` in a rails console, but I feel like this library should be able to cope with that.

```irb
> MyModel
=> MyModel(id: integer, updated_at: datetime)

> pubs = RooOnRails::Routemaster::Publishers.instance_variable_get('@publishers')
=> {MyModel(id: integer, updated_at: datetime)=>#<Set: {MyModelPublisher}>}

> RooOnRails::Routemaster::Publishers.for(MyModel.first, :update)
=> [#<ApplicationPublisher:0x007fc220718790 @_routes=nil, @model=#<MyModel id: 243, updated_at: "2017-08-30 19:50:03">, @event=:update, @client=Routemaster::Client>]

> pubs[MyModel]
=> nil

> MyModel
=> MyModel(id: integer, updated_at: datetime)

> pubs.keys.first
=> MyModel(id: integer, updated_at: datetime)

> MyModel.object_id
=> 70235881143460

> pubs.keys.first.object_id
=> 70235880994880

```