### PR TITLE
Declare the event's timestamp according to model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 - Friendlier error message when facing Heroku permission errors (#58)
 - Replaces the Rails logger with a structured logger (#60)
 - Bugfix for supporting non-default publishers after a `reload!` in the rails console (#62)
+- Auto-fills the Routemaster `t` timestamp field, where appropriate, from the model's `created_at` and `updated_at` fields if available (#64)
 
 
 # v1.10.0 (2017-08-11)

--- a/README.routemaster_client.md
+++ b/README.routemaster_client.md
@@ -78,6 +78,8 @@ class RiderPublisher < ApplicationPublisher
 end
 ```
 
+`#publish?`, `#topics`, `#async?`, `#data` and `#timestamp` can be overriden; see [the `Publisher` class](lib/roo_on_rails_routemaster/publisher.rb) for the default implementations.
+
 ### Register the publishers with Routemaster
 
 The final step is to tell Routemaster that these publishers exist, so that it can listen to their events. We're going to do this in an initialiser:

--- a/lib/roo_on_rails/routemaster/publisher.rb
+++ b/lib/roo_on_rails/routemaster/publisher.rb
@@ -22,7 +22,14 @@ module RooOnRails
 
       def publish!
         return unless will_publish?
-        @client.send(@event, topic, url, async: async?, data: stringify_keys(data))
+        @client.send(
+          @event,
+          topic,
+          url,
+          async: async?,
+          data: stringify_keys(data),
+          t: timestamp && timestamp.to_i
+        )
       end
 
       def topic
@@ -38,6 +45,12 @@ module RooOnRails
       end
 
       def data
+        nil
+      end
+
+      def timestamp
+        return @model.created_at if created? && @model.respond_to?(:created_at)
+        return @model.updated_at if (updated? || created?) && @model.respond_to?(:updated_at)
         nil
       end
 

--- a/spec/roo_on_rails/routemaster/publisher_spec.rb
+++ b/spec/roo_on_rails/routemaster/publisher_spec.rb
@@ -1,10 +1,10 @@
 require 'active_support/core_ext/string'
 require 'roo_on_rails/routemaster/publisher'
+require 'support/test_model'
 
 RSpec.describe RooOnRails::Routemaster::Publisher do
   TestPublisherA = Class.new(RooOnRails::Routemaster::Publisher)
   TestPublisherB = Class.new(RooOnRails::Routemaster::Publisher)
-  TestModel = Class.new
   let(:model) { TestModel.new }
   let(:event) { :noop }
 
@@ -32,7 +32,8 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
           data: {
             "test_key_1" => "Test value 1",
             "test_key_2" => "Test value 2"
-          }
+          },
+          t: nil
         }
       )
       publisher.publish!
@@ -55,6 +56,52 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
       expect(publisher.updated?).to eq(false)
       expect(publisher.deleted?).to eq(false)
       expect(publisher.noop?).to eq(true)
+    end
+
+    describe 'the timestamp of the event sent to routemaster' do
+      subject(:timestamp) do
+        ts = nil
+        expect(::Routemaster::Client).to receive(:send) { |_, _, _, opts| ts = opts[:t] }
+        publisher.publish!
+        ts
+      end
+
+      context 'when the model was created' do
+        let(:event) { :created }
+
+        context 'when the model responds to created_at' do
+          let(:create_time) { Time.at(12345) }
+          let(:model) { TestModel.which_responds_to(created_at: create_time).new }
+
+          it { should eq create_time.to_i }
+        end
+
+        context 'when the model does not respond to created_at' do
+          # it { should eq nil }
+
+          context 'when the model responds to updated_at' do
+            let(:update_time) { Time.at(23456) }
+            let(:model) { TestModel.which_responds_to(updated_at: update_time).new }
+
+            it { should eq update_time.to_i }
+          end
+        end
+      end
+
+      context 'when the model was updated' do
+        let(:event) { :updated }
+
+        context 'when the model does not respond to updated_at' do
+          it { should eq nil }
+        end
+
+        context 'when the model responds to updated_at' do
+          let(:update_time) { Time.at(34567) }
+          let(:model) { TestModel.which_responds_to(updated_at: update_time).new }
+
+          it { should eq update_time.to_i }
+        end
+      end
     end
   end
 

--- a/spec/roo_on_rails/routemaster/publishers_spec.rb
+++ b/spec/roo_on_rails/routemaster/publishers_spec.rb
@@ -1,8 +1,8 @@
 require 'roo_on_rails/routemaster/publisher'
 require 'roo_on_rails/routemaster/publishers'
+require 'support/test_model'
 
 RSpec.describe RooOnRails::Routemaster::Publishers do
-  TestModel = Class.new
   TestPublisherA = Class.new(RooOnRails::Routemaster::Publisher)
   TestPublisherB = Class.new(RooOnRails::Routemaster::Publisher)
 

--- a/spec/support/test_model.rb
+++ b/spec/support/test_model.rb
@@ -1,0 +1,30 @@
+# An active-model-like class which is used in tests
+class TestModel
+
+  # This means #will_publish? will always be true
+  def new_record?
+    true
+  end
+
+  # Defines a new test model which will respond to the given
+  # methods.
+  #
+  # @example:
+  #   m = TestModel.which_responds_to(updated_at: -> { Time.now })
+  #
+  #   m.new.updated_at
+  #   # => 2017-09-01 13:26:18 +0100
+  def self.which_responds_to(**methods_and_repsonses)
+    Class.new(self) do
+      def self.name
+        'AnonymousTestModelClass'
+      end
+
+      methods_and_repsonses.each do |method_name, response|
+        block = response.respond_to?(:call) ? response : -> { response }
+        define_method(method_name, &block)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
When the model responds to `#created_at` or `#updated_at` then make an intelligent guess as to the timestamp the event should be declared as having.

Also introduces a `#timestamp` method on a publisher which can override this.