### PR TITLE
Fix bug when SIDEKIQ_ENABLED is false, rails won't load.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Bug fixes:
+
+- Fix case when SIDEKIQ_ENABLED was false, rails would not load.
+
 # v1.11.0 (2017-08-11)
 
 Features (library):

--- a/lib/roo_on_rails/railties/sidekiq.rb
+++ b/lib/roo_on_rails/railties/sidekiq.rb
@@ -11,7 +11,7 @@ module RooOnRails
         Rails.logger.with initializer: 'roo_on_rails.sidekiq' do |log|
           
           unless RooOnRails::Config.sidekiq_enabled?
-            logger.debug 'skipping'
+            log.debug 'skipping'
             next
           end
 


### PR DESCRIPTION
This was caused by incorrect variable naming.

I couldn't see any tests for the railties to add to - I assume that these are particularly difficult to test?