### PR TITLE
Add a controller concern for authenticating routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+Features (library):
+- Provides API authentication concern for controllers. (#67)
+
 # v1.11.1 (2017-09-11)
 
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -256,6 +256,34 @@ When `ROUTEMASTER_ENABLED` is set to `true` we attempt to configure [`routemaste
 
 If you then want to enable the publishing of events onto the event bus, you need to set `ROUTEMASTER_PUBLISHING_ENABLED` to `true` and implement publishers as needed. An example of how to do this is detailed in [`README.routemaster_client.md`](README.routemaster_client.md).
 
+### API Authentication
+
+RooOnRails provides a concern which will make adding rotatable API authentication to your service a breeze:
+
+```ruby
+require 'roo_on_rails/concerns/require_api_key'
+
+class ThingController < ActionController::Base
+  require_api_key
+  # or
+  require_api_key(only: :update)
+  # or
+  require_api_key(only_services: %i(service_1 service_2))
+
+  def index
+    # etc
+end
+```
+
+Keys are specified in environment variables ending with `_CLIENT_KEY`, where the value is a comma separated list of keys which the specified service can authenticate with. This means that if your service has the environment variables:
+
+```
+SERVICE_1_CLIENT_KEY=abc123abc123,def456def456
+SERVICE_2_CLIENT_KEY=I-never-could-get-the-hang-of-Thursdays
+```
+
+Then, for any controller where this concern has been initiated, Basic Authentication will be required and only `service_1:abc123abc123`, `service_1:def456def456` and `service_2:I-never-could-get-the-hang-of-Thursdays` will be allowed access.
+
 ## Command features
 
 ### Usage

--- a/lib/roo_on_rails/concerns/require_api_key.rb
+++ b/lib/roo_on_rails/concerns/require_api_key.rb
@@ -40,8 +40,8 @@ module RooOnRails
         # @see AbstractController::Callbacks::ClassMethods#before_action for additional scoping opts
         def require_api_key(only_services: nil, **options)
           before_action(**options) do
-            authenticate_or_request_with_http_basic('actor-tracking') do |service_name, client_key|
-              Authenticator.new(*only_services).valid?(service_name, client_key).tap do |is_valid|
+            authenticate_or_request_with_http_basic('Authenitcation required') do |service_name, client_key|
+              Authenticator.new([*only_services]).valid?(service_name, client_key).tap do |is_valid|
                 @current_client = OpenStruct.new(name: service_name).freeze if is_valid
               end
             end

--- a/lib/roo_on_rails/concerns/require_api_key.rb
+++ b/lib/roo_on_rails/concerns/require_api_key.rb
@@ -1,0 +1,108 @@
+require 'active_support/concern'
+require 'action_controller/metal/http_authentication'
+
+module RooOnRails
+  module Concerns
+    # This concern allows API authentication in a consistent manner.
+    #
+    # If a service connects with basic auth using the username "service" then the
+    # `SERVICE_CLIENT_KEY` environment variable must have the given password as one of
+    # the comma separated strings within it or a 403 will be raised.
+    #
+    # @example: Any service with an acceptable key can access routes
+    #
+    #     class ThingController < ApplicationController
+    #       include RooOnRails::Concerns::RequireApiKey
+    #       require_api_key
+    #
+    #       # etc
+    #     end
+    #
+    # @example: Only the specified clients can access specific routes in this controller
+    #
+    #     class ThingController < ApplicationController
+    #       include RooOnRails::Concerns::RequireApiKey
+    #       require_api_key(only_services: :my_service, only: :create)
+    #
+    #       # etc
+    #     end
+    module RequireApiKey
+      extend ActiveSupport::Concern
+      include ActionController::HttpAuthentication::Basic::ControllerMethods
+
+      attr_reader :current_client
+
+      module ClassMethods
+        # Declares that routes on the controller must have access credentials specified
+        # in the request that match the approparite environment variables.
+        #
+        # @param :only_services (#to_s,Array<#to_s>) Restricts the services which will be accepted
+        # @see AbstractController::Callbacks::ClassMethods#before_action for additional scoping opts
+        def require_api_key(only_services: nil, **options)
+          before_action(**options) do
+            authenticate_or_request_with_http_basic('actor-tracking') do |service_name, client_key|
+              Authenticator.new(*only_services).valid?(service_name, client_key).tap do |is_valid|
+                @current_client = OpenStruct.new(name: service_name).freeze if is_valid
+              end
+            end
+          end
+        end
+      end
+
+      # This functionality pulled out into a new class for testability
+      class Authenticator
+        def initialize(whitelisted_clients)
+          @whitelisted_clients = whitelisted_clients.map(&:to_s)
+        end
+
+        def valid?(service_name, client_key)
+          return false unless whitelisted?(service_name)
+
+          NewRelic::Agent.add_custom_attributes(httpBasicUserId: service_name) if defined?(NewRelic)
+          ClientApiKeys.instance.valid?(service_name, client_key)
+        end
+
+        private
+
+        def whitelisted?(service_name)
+          return true if @whitelisted_clients.empty?
+          @whitelisted_clients.include?(service_name)
+        end
+      end
+
+      class ClientApiKeys
+        include Singleton
+
+        CLIENT_KEY_NAME_SUFFIX_REGEX = /_CLIENT_KEY\Z/
+
+        def initialize
+          @cache = ENV.select { |key| key =~ CLIENT_KEY_NAME_SUFFIX_REGEX }
+                      .map { |k, v| [service_name(k), parse_client_keys(v)] }
+                      .to_h
+                      .freeze
+        end
+
+        def valid?(service_name, client_key)
+          return false if service_name == '' || client_key == ''
+
+          client_keys = @cache[normalize(service_name)]
+          client_keys && client_keys.include?(client_key)
+        end
+
+        private
+
+        def service_name(client_key_name)
+          normalize(client_key_name.sub(CLIENT_KEY_NAME_SUFFIX_REGEX, ''))
+        end
+
+        def normalize(service_name)
+          service_name.upcase.gsub(/[A-Z0-9]+/, '_')
+        end
+
+        def parse_client_keys(str)
+          (str || '').split(',').map(&:strip).to_set.freeze
+        end
+      end
+    end
+  end
+end

--- a/spec/roo_on_rails/concerns/require_api_key_spec.rb
+++ b/spec/roo_on_rails/concerns/require_api_key_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'roo_on_rails/concerns/require_api_key'
+
+RSpec.describe RooOnRails::Concerns::RequireApiKey do
+  # This class is incredibly hard to test _as_ a controller concern as
+  # we would have to instantiate an entire rails application in order to test the parts of
+  # this concern which are already tested within rails, so the new authentication logic is
+  # pulled out into the `Authenticator` class for testing.
+
+  describe RooOnRails::Concerns::RequireApiKey::Authenticator do
+    subject(:described_instance) { described_class.new(whitelisted_services) }
+
+    let(:real_key) { 'apikey' }
+    let(:stubbed_env) { {
+      'SOME_SERVICE_CLIENT_KEY' => real_key,
+      'SOME_OTHER_SERVICE_CLIENT_KEY' => real_key,
+    } }
+
+    before do
+      allow(ENV).to receive(:select) do |&block|
+        stubbed_env.select(&block)
+      end
+    end
+
+    describe '#valid?' do
+      subject(:described_method) { described_instance.valid?(given_service, given_key) }
+      let(:given_service) { 'some_service' }
+      let(:whitelisted_services) { [] }
+
+      context 'when giving a valid client key' do
+        let(:given_key) { real_key }
+
+        it { should eq true }
+
+        context 'when some services are whitelisted' do
+          let(:whitelisted_services) { ['some_service'] }
+
+          context 'when the given service is in the whitelist' do
+            it { should eq true }
+          end
+
+          context 'when the given service is not in the whitelist' do
+            let(:given_service) { 'some_other_service' }
+
+            it { should eq false }
+          end
+        end
+      end
+
+      context 'when giving a invalid client key' do
+        let(:given_key) { 'notcorrect' }
+
+        it { should eq false }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@ RSpec.configure do |config|
   require_relative './support/sidekiq_queue_helpers'
   config.include(SidekiqQueueHelpers)
 
+  config.filter_run(focus: true) unless ENV['CONTINUOUS_INTEGRATION']
+  config.run_all_when_everything_filtered = true
+
   config.filter_run_excluding rails_min_version: (lambda { |_, meta|
     require 'rails'
     Gem::Version.new(meta[:rails_min_version]) >= Gem::Version.new(Rails::VERSION::STRING)


### PR DESCRIPTION
This concern allows API authentication in a consistent manner.

If a service connects with basic auth using the username "service" then the
`SERVICE_CLIENT_KEY` environment variable must have the given password as one of
the comma separated strings within it or a 403 will be raised.

Any service with an acceptable key can access routes:
```ruby
class ThingController < ApplicationController
  include RooOnRails::Concerns::RequireApiKey
  require_api_key

  # etc
end
```

Only the specified clients can access specific routes in this controller:
```ruby
class ThingController < ApplicationController
  include RooOnRails::Concerns::RequireApiKey
  require_api_key(only_services: :my_service, only: :create)

  # etc
end
```