### PR TITLE
Add configuration for rtm-client's SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# HEAD
+
+Features:
+
+- Provide `ROUTEMASTER_VERIFY_SSL` environment variable to disable
+  routemaster-client's SSL verification. (#68)
+
 # v1.12.0 (2017-09-27)
 
 Features (library):

--- a/README.md
+++ b/README.md
@@ -249,10 +249,11 @@ These extra required variables are automatically set by Heroku:
 
 ### Routemaster Client
 
-When `ROUTEMASTER_ENABLED` is set to `true` we attempt to configure [`routemaster-client`](https://github.com/deliveroo/routemaster-client) on your application. In order for this to happen you need to set the following environment variables:
+When `ROUTEMASTER_ENABLED` is set to `true` we attempt to configure [`routemaster-client`](https://github.com/deliveroo/routemaster-client) on your application. In order for this to happen, set the following environment variables:
 
 * `ROUTEMASTER_URL` – the full URL of your Routemaster application (mandatory)
 * `ROUTEMASTER_UUID` – the UUID of your application, e.g. `logistics-dashboard` (mandatory)
+* `ROUTEMASTER_VERIFY_SSL` – set to false if your Routemaster application is not served with a valid cert. (optional)
 
 If you then want to enable the publishing of events onto the event bus, you need to set `ROUTEMASTER_PUBLISHING_ENABLED` to `true` and implement publishers as needed. An example of how to do this is detailed in [`README.routemaster_client.md`](README.routemaster_client.md).
 

--- a/lib/roo_on_rails/railties/routemaster.rb
+++ b/lib/roo_on_rails/railties/routemaster.rb
@@ -15,6 +15,7 @@ module RooOnRails
           ::Routemaster::Client.configure do |config|
             config.url = routemaster_url
             config.uuid = routemaster_uuid
+            config.verify_ssl = routemaster_verify_ssl
           end
         end
       end
@@ -31,6 +32,10 @@ module RooOnRails
 
       def routemaster_uuid
         ENV.fetch('ROUTEMASTER_UUID')
+      end
+
+      def routemaster_verify_ssl
+        ENV.fetch('ROUTEMASTER_VERIFY_SSL', 'true') != 'false'
       end
     end
   end


### PR DESCRIPTION
Not all environments, e.g., development, will serve Routemaster with a valid SSL
cert.