### PR TITLE
Add docs for Hirefire for Web Dynos

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ Web dynos can be autoscaled by HireFire _only_ if it has been configured to use 
 $ heroku labs:enable log-runtime-metrics -a your-service-name-here
 ```
 
+You will also need a log drain for HireFire, but the RooOnRails helper below should configure this for you. You can check with
+
+```bash
+$ heroku drains | grep hirefire
+https://logdrain.hirefire.io (d.00000000-0000-0000-0000-000000000000)
+
+# No drain? Add with:
+$ heroku drains:add -a your-service-name-here https://logdrain.hirefire.io
+```
+
+([HireFire docs for set up](https://help.hirefire.io/guides/logplex/load-logplex))
+
 #### For Sidekiq Workers
 
 When `HIREFIRE_TOKEN` is set an endpoint will be mounted at `/hirefire` that

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   - [Rack middleware](#rack-middleware)
   - [Database configuration](#database-configuration)
   - [Sidekiq](#sidekiq)
-  - [HireFire (for Sidekiq workers)](#hirefire-for-sidekiq-workers)
+  - [HireFire](#hirefire)
   - [Logging](#logging)
   - [Google OAuth authentication](#google-oauth-authentication)
   - [Datadog Integration](#datadog-integration)
@@ -128,7 +128,17 @@ NB. If you are migrating to SLA-based queue names, do not set `SIDEKIQ_ENABLED`
 to `true` before your old queues have finished processing (this will prevent
 Sidekiq from seeing the old queues at all).
 
-### HireFire (for Sidekiq workers)
+### HireFire
+
+#### For Web Dynos
+
+Web dynos can be autoscaled by HireFire _only_ if it has been configured to use the `Web.Logplex.Load` source and the Heroku runtime metrics lab feature has been enabled:
+
+```bash
+$ heroku labs:enable log-runtime-metrics -a your-service-name-here
+```
+
+#### For Sidekiq Workers
 
 When `HIREFIRE_TOKEN` is set an endpoint will be mounted at `/hirefire` that
 reports the required worker count as a function of queue latency. By default we


### PR DESCRIPTION
I've added a note in the README for adding HireFire integration for Web dynos (as well as sidekiq users). This _could_ be turned into a RooOnRails plugin, but I figured I'd start with docs. (See SETI-795)