### PR TITLE
Fix painful missing caret

### DIFF
--- a/lib/roo_on_rails/concerns/require_api_key.rb
+++ b/lib/roo_on_rails/concerns/require_api_key.rb
@@ -86,7 +86,8 @@ module RooOnRails
           return false if service_name == '' || client_key == ''
 
           client_keys = @cache[normalize(service_name)]
-          client_keys && client_keys.include?(client_key)
+          return false unless client_keys
+          client_keys.include?(client_key)
         end
 
         private
@@ -96,7 +97,7 @@ module RooOnRails
         end
 
         def normalize(service_name)
-          service_name.upcase.gsub(/[A-Z0-9]+/, '_')
+          service_name.upcase.gsub(/[^A-Z0-9]+/, '_')
         end
 
         def parse_client_keys(str)

--- a/spec/roo_on_rails/concerns/require_api_key_spec.rb
+++ b/spec/roo_on_rails/concerns/require_api_key_spec.rb
@@ -47,8 +47,15 @@ RSpec.describe RooOnRails::Concerns::RequireApiKey do
         end
       end
 
-      context 'when giving a invalid client key' do
+      context 'when giving an invalid client key' do
         let(:given_key) { 'notcorrect' }
+
+        it { should eq false }
+      end
+
+      context 'when giving an invalid client name' do
+        let(:given_key) { real_key }
+        let(:given_service) { 'not_real_service' }
 
         it { should eq false }
       end


### PR DESCRIPTION
The missing caret meant that service names were incorrectly processed (both for tracking purposes, and for authentication purposes). A correct password would still be required, but it wouldn't necessarily be from the correct associated service. 

This fixes the issue and proves the problem with a new test.