### PR TITLE
Fix: Handle the case when service_name is nill in auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# v1.12.0 (2017-10-12)
+# v1.13.1 (2017-10-18)
+
+Bug fix:
+
+- Fixes issue when `service_name` is null in `require_api_key` (#74)
+
+# v1.13.0 (2017-10-12)
 
 Features:
 

--- a/lib/roo_on_rails/concerns/require_api_key.rb
+++ b/lib/roo_on_rails/concerns/require_api_key.rb
@@ -83,7 +83,7 @@ module RooOnRails
         end
 
         def valid?(service_name, client_key)
-          return false if service_name == '' || client_key == ''
+          return false if service_name.to_s.empty? || client_key.to_s.empty?
 
           client_keys = @cache[normalize(service_name)]
           return false unless client_keys

--- a/spec/roo_on_rails/concerns/require_api_key_spec.rb
+++ b/spec/roo_on_rails/concerns/require_api_key_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe RooOnRails::Concerns::RequireApiKey do
 
         it { should eq false }
       end
+
+      context 'when giving a nil client name' do
+        let(:given_key) { real_key }
+        let(:given_service) { nil }
+
+        it { should eq false }
+      end
+
+      context 'when giving an empty client name' do
+        let(:given_key) { real_key }
+        let(:given_service) { '' }
+
+        it { should eq false }
+      end
     end
   end
 end


### PR DESCRIPTION
### Background

It appears, due to bad configuration, `service_name` may be nil in the authentication logic. This needs to be handled gracefully so the system will continue with an `unauthorised` rather than an unhandled error [showing up in NewRelic](https://rpm.newrelic.com/accounts/881102/applications/53286913/traced_errors/1df4d3d5-b3ea-11e7-beb1-0242ac110008_0_12325)