### PR TITLE
 delegate to `ActiveSupport::Logger` instead of `Logger` if Rails version > 3

### DIFF
--- a/lib/roo_on_rails/logger.rb
+++ b/lib/roo_on_rails/logger.rb
@@ -1,6 +1,6 @@
-require 'logger'
 require 'delegate'
 require 'roo_on_rails/logfmt'
+require 'active_support/logger'
 
 module RooOnRails
   # A compatible replacement for the standard Logger to provide context, similar
@@ -30,7 +30,7 @@ module RooOnRails
   class Logger < SimpleDelegator
     def initialize(io = STDOUT)
       @show_timestamp = io.tty?
-      logger = ::Logger.new(io).tap do |l|
+      logger = ActiveSupport::Logger.new(io).tap do |l|
         l.formatter = method(:_formatter)
       end
       super(logger)

--- a/lib/roo_on_rails/logger.rb
+++ b/lib/roo_on_rails/logger.rb
@@ -1,6 +1,12 @@
 require 'delegate'
 require 'roo_on_rails/logfmt'
-require 'active_support/logger'
+require 'rails/version'
+
+if Rails::VERSION::MAJOR < 4
+  require 'logger'
+else
+  require 'active_support/logger'
+end
 
 module RooOnRails
   # A compatible replacement for the standard Logger to provide context, similar
@@ -30,7 +36,7 @@ module RooOnRails
   class Logger < SimpleDelegator
     def initialize(io = STDOUT)
       @show_timestamp = io.tty?
-      logger = ActiveSupport::Logger.new(io).tap do |l|
+      logger = _default_logger_class.new(io).tap do |l|
         l.formatter = method(:_formatter)
       end
       super(logger)
@@ -99,6 +105,14 @@ module RooOnRails
       # We use our object ID here to avoid conflicting with other instances
       thread_key = @_context_stack_key ||= "roo_on_rails:logging_context:#{object_id}".freeze
       Thread.current[thread_key] ||= [{}]
+    end
+
+    def _default_logger_class
+      if Rails::VERSION::MAJOR < 4
+        ::Logger
+      else
+        ActiveSupport::Logger
+      end
     end
   end
 end

--- a/spec/roo_on_rails/logger_spec.rb
+++ b/spec/roo_on_rails/logger_spec.rb
@@ -54,4 +54,11 @@ RSpec.describe RooOnRails::Logger do
       end
     end
   end
+
+  describe '#silence' do
+    before { logger.silence { logger.info('hello-world') } }
+    it 'should not output any log' do
+      expect(output).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This defaults delegating to `ActiveSupport::Logger` if available so we can use methods like [`#silence`](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/logger.rb#L61).

This fixes #76 