### PR TITLE
LOG-2010: Roo on Rails: fix sending events t to Routemaster

### DIFF
--- a/lib/roo_on_rails/routemaster/publisher.rb
+++ b/lib/roo_on_rails/routemaster/publisher.rb
@@ -28,7 +28,7 @@ module RooOnRails
           url,
           async: async?,
           data: stringify_keys(data),
-          t: timestamp && timestamp.to_i
+          t: timestamp && (timestamp.to_f * 1000).to_i
         )
       end
 

--- a/lib/roo_on_rails/version.rb
+++ b/lib/roo_on_rails/version.rb
@@ -1,3 +1,3 @@
 module RooOnRails
-  VERSION = '1.13.1'.freeze
+  VERSION = '1.14.0'.freeze
 end

--- a/lib/roo_on_rails/version.rb
+++ b/lib/roo_on_rails/version.rb
@@ -1,3 +1,3 @@
 module RooOnRails
-  VERSION = '1.14.0'.freeze
+  VERSION = '1.13.1'.freeze
 end

--- a/spec/roo_on_rails/routemaster/publisher_spec.rb
+++ b/spec/roo_on_rails/routemaster/publisher_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
           let(:create_time) { Time.at(12345) }
           let(:model) { TestModel.which_responds_to(created_at: create_time).new }
 
-          it { should eq create_time.to_i }
+          it { should eq (create_time.to_f * 1000).to_i }
         end
 
         context 'when the model does not respond to created_at' do
@@ -83,7 +83,7 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
             let(:update_time) { Time.at(23456) }
             let(:model) { TestModel.which_responds_to(updated_at: update_time).new }
 
-            it { should eq update_time.to_i }
+            it { should eq (update_time.to_f * 1000).to_i }
           end
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe RooOnRails::Routemaster::Publisher do
           let(:update_time) { Time.at(34567) }
           let(:model) { TestModel.which_responds_to(updated_at: update_time).new }
 
-          it { should eq update_time.to_i }
+          it { should eq (update_time.to_f * 1000).to_i }
         end
       end
     end


### PR DESCRIPTION
Publisher was sending epoch seconds instead of milliseconds as RM expects.

===

Jira story [#LOG-2010](https://deliveroo.atlassian.net/browse/LOG-2010) in project *Logistics*:

> Roo on Rails is senting "t" in seconds, but Routemaster expects milliiseconds. Fix it.