### PR TITLE
Add ability to create exceptions to SSL enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ We'll insert the following middlewares into the rails stack:
    with `ROO_ON_RAILS_RACK_DEFLATE` (default: 'YES').
 4. Optional middlewares for Google Oauth2 (more below).
 
+#### Adding an exception to `Rack::SslEnforcer`
+
+If you're running your application on Hopper and need to serve a health check
+over HTTP, or if for any other reason you might need to serve a particular endpoint
+over HTTP rather than HTTPS, you can use the `ROO_ON_RAILS_SSL_ENFORCEMENT_EXCEPTIONS`
+environment variable to specify a comma-delimited list of endpoints, for example
+`ROO_ON_RAILS_SSL_ENFORCEMENT_EXCEPTIONS=/health`.
+
 ### Database configuration
 
 The database statement timeout will be set to a low value by default. Use

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -18,7 +18,7 @@ module RooOnRails
             ::Rack::Timeout
           )
 
-          middleware_to_insert_before = Rails::VERSION::MAJOR < 4 ? ::ActionDispatch::Cookies : ::Rack::Head 
+          middleware_to_insert_before = Rails::VERSION::MAJOR < 4 ? ::ActionDispatch::Cookies : ::Rack::Head
 
           # This needs to be inserted low in the stack, before Rails returns the
           # thread-current connection to the pool.
@@ -37,7 +37,8 @@ module RooOnRails
           unless Rails.env.test?
             app.config.middleware.insert_before(
               middleware_to_insert_before,
-              ::Rack::SslEnforcer
+              ::Rack::SslEnforcer,
+              ignore: ENV.fetch('ROO_ON_RAILS_SSL_ENFORCEMENT_EXCEPTIONS', '').split(',')
             )
           end
         end


### PR DESCRIPTION
As we move more services onto AWS, we need to serve a health check
over HTTP that returns an 200 status code. At the moment, this
doesn't work for apps using `roo_on_rails` – `Rack::SslEnforcer`
redirects the health check request, which means it returns a 301
status code, and the health check fails.

This adds an environment variable – the ever-so-catchily named
`ROO_ON_RAILS_SSL_ENFORCEMENT_EXCEPTIONS` – that allows developers
to specify a comma-delimited list of exact paths that should be
excluded from SSL enforcement.