### PR TITLE
Ensure JWTs work across environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # HEAD
 
-_A description of your awesome new stuff here!_
+Bug fix:
+
+- Ensure we can distinguish between environments' identity services (#81)
 
 # v1.15.0
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ available:
 require 'roo_on_rails/railties/roo_identity'
 ```
 
+In non-development environments you must also set the `VALID_IDENTITY_URL_PREFIXES` environment
+variable to be a comma separasted list of the URL prefixes which valid JWTs come from, eg:
+
+```
+https://deliveroo.co.uk/identity-keys/,https://identity.deliveroo.com/jwks/
+```
+
 Any inbound request which has a valid JWT will have the claims made available:
 
 ```ruby

--- a/lib/roo_on_rails/rack/valid_identity_service_prefixes.yml
+++ b/lib/roo_on_rails/rack/valid_identity_service_prefixes.yml
@@ -1,6 +1,0 @@
-production:
-  - https://deliveroo.co.uk/identity-keys/
-  - https://identity.deliveroo.net/identity/keys/
-staging:
-  - https://test.deliveroo.co.uk/identity-keys/
-  - https://identity-staging.deliveroo.net/identity-keys/


### PR DESCRIPTION
Using `RACK_ENV` is not a valid way of distinguishing between production and staging, as for both of those environments it will be "production"!

This moves to using the `VALID_IDENTITY_URL_PREFIXES` environment variable (and will crash non-development environments which don't have it set) so that you must always set the places where keys are valid from.