### PR TITLE
Add ability to disable SSL enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Bug fix:
 
 - Ensure we can distinguish between environments' identity services (#81)
 
+Features:
+
+- Allow SSL enforcement to be disabled via `ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT` environment variable (#82)
+
 # v1.15.0
 
 Features:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ We'll insert the following middlewares into the rails stack:
    with `ROO_ON_RAILS_RACK_DEFLATE` (default: 'YES').
 4. Optional middlewares for Google Oauth2 (more below).
 
+
+#### Disabling SSL enforcement
+
+If you're running your application on Hopper, you'll need to turn off SSL enforcement
+as we do that at edge level in Cloudflare rather than the application code itself,
+which must be served over HTTP to its associated ALB, which handles SSL termination.
+To do this, you can set the `ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT` to `YES`.
+
 ### Database configuration
 
 The database statement timeout will be set to a low value by default. Use

--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -18,7 +18,7 @@ module RooOnRails
             ::Rack::Timeout
           )
 
-          middleware_to_insert_before = Rails::VERSION::MAJOR < 4 ? ::ActionDispatch::Cookies : ::Rack::Head 
+          middleware_to_insert_before = Rails::VERSION::MAJOR < 4 ? ::ActionDispatch::Cookies : ::Rack::Head
 
           # This needs to be inserted low in the stack, before Rails returns the
           # thread-current connection to the pool.
@@ -34,7 +34,8 @@ module RooOnRails
           end
 
           # Don't use SslEnforcer in test environment as it breaks Capybara
-          unless Rails.env.test?
+          unless Rails.env.test? ||
+                 ENV.fetch('ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT', '') =~ /\A(YES|TRUE|ON|1)\Z/i
             app.config.middleware.insert_before(
               middleware_to_insert_before,
               ::Rack::SslEnforcer

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -8,7 +8,7 @@ describe 'Http rack setup' do
   context 'When booting' do
     let(:middleware) { app_helper.shell_run "cd #{app_path} && rake middleware" }
 
-    it 'inserts rack timeout into the middleware stack' do      
+    it 'inserts rack timeout into the middleware stack' do
       expect(middleware).to include 'Rack::Timeout'
     end
 
@@ -29,9 +29,18 @@ describe 'Http rack setup' do
       end
     end
 
-    context 'if RAILS_ENV is not set to "test"' do
+    context 'if RAILS_ENV is not set to "test" and ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT is not set' do
       it 'inserts rack enforcer into the middleware stack' do
         expect(middleware).to include 'Rack::SslEnforcer'
+      end
+    end
+
+    context 'if ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT is set to "YES"' do
+      before { ENV['ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT'] = 'YES' }
+      after { ENV['ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT'] = nil }
+
+      it 'does not insert Rack::SslEnforcer into the middleware stack' do
+        expect(middleware).to_not include 'Rack::SslEnforcer'
       end
     end
 


### PR DESCRIPTION
This adds an option to RoR to disable SSL enforcement, which is
required for applications deployed to Hopper.