### PR TITLE
do not disable db connection reaping by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bug fix:
 
 - It's possible to set an invalid log level and crash on boot (#84)
+- Do not disable ActiveRecord connection reaping by default; set default behaviour to Rails' default behaviour.
 
 # v1.16.1 (2017-11-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Bug fix:
 
 - It's possible to set an invalid log level and crash on boot (#84)
-- Do not disable ActiveRecord connection reaping by default; set default behaviour to Rails' default behaviour.
+- Do not disable ActiveRecord connection reaping by default; set default behaviour to Rails' default behaviour. (#85)
 
 # v1.16.1 (2017-11-20)
 

--- a/lib/roo_on_rails/railties/database.rb
+++ b/lib/roo_on_rails/railties/database.rb
@@ -9,7 +9,9 @@ module RooOnRails
             config = ActiveRecord::Base.configurations[Rails.env]
             config['variables'] ||= {}
             config['variables']['statement_timeout'] = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', 200)
-            config['reaping_frequency'] = ENV['DATABASE_REAPING_FREQUENCY']
+            if ENV.key?('DATABASE_REAPING_FREQUENCY')
+              config['reaping_frequency'] = ENV['DATABASE_REAPING_FREQUENCY']
+            end
 
             ActiveRecord::Base.establish_connection
           end


### PR DESCRIPTION
Rails has default db connection reaping interval set to 60 seconds.
[source](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L361)

But we're disabling db connection reaping completely by setting it to
`nil` unless a particular environment variable is defined.

This change ensures that the default behaviour matches Rails'.