### PR TITLE
Change New Relic initialization to use init_plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 _A description of your awesome changes here!_
 
+Bug fix:
+
+- Avoid New Relic initialization warning by following Rails initializer behaviour
+
+Features:
+
+- Allow disabling New Relic synchronous startup by setting `NEW_RELIC_SYNC_STARTUP=false`
+
 # v1.18.0 (2018-01-11)
 
 Features:

--- a/lib/roo_on_rails/railties/new_relic.rb
+++ b/lib/roo_on_rails/railties/new_relic.rb
@@ -19,7 +19,7 @@ module RooOnRails
             abort "Aborting: newrelic.yml detected in '#{path.parent.realpath}', should not exist"
           end
 
-          sync_startup = ENV.fetch('NEW_RELIC_SYNC_STARTUP', 'YES').match?(/\A(YES|TRUE|ON|1)\Z/i)
+          sync_startup = (ENV.fetch('NEW_RELIC_SYNC_STARTUP', 'YES') =~ /\A(YES|TRUE|ON|1)\Z/i)
 
           require 'newrelic_rpm'
           unless Rails.env.test?

--- a/lib/roo_on_rails/railties/new_relic.rb
+++ b/lib/roo_on_rails/railties/new_relic.rb
@@ -19,7 +19,7 @@ module RooOnRails
             abort "Aborting: newrelic.yml detected in '#{path.parent.realpath}', should not exist"
           end
 
-          sync_startup = !(ENV['NEW_RELIC_SYNC_STARTUP'].to_s.downcase == 'false')
+          sync_startup = ENV.fetch('NEW_RELIC_SYNC_STARTUP', 'YES').match?(/\A(YES|TRUE|ON|1)\Z/i)
 
           require 'newrelic_rpm'
           unless Rails.env.test?

--- a/lib/roo_on_rails/railties/new_relic.rb
+++ b/lib/roo_on_rails/railties/new_relic.rb
@@ -19,8 +19,12 @@ module RooOnRails
             abort "Aborting: newrelic.yml detected in '#{path.parent.realpath}', should not exist"
           end
 
+          sync_startup = !(ENV['NEW_RELIC_SYNC_STARTUP'] == 'false')
+
           require 'newrelic_rpm'
-          ::NewRelic::Agent.manual_start unless Rails.env.test?
+          unless Rails.env.test?
+            ::NewRelic::Control.instance.init_plugin(sync_startup: sync_startup)
+          end
         end
       end
     end

--- a/lib/roo_on_rails/railties/new_relic.rb
+++ b/lib/roo_on_rails/railties/new_relic.rb
@@ -19,7 +19,7 @@ module RooOnRails
             abort "Aborting: newrelic.yml detected in '#{path.parent.realpath}', should not exist"
           end
 
-          sync_startup = !(ENV['NEW_RELIC_SYNC_STARTUP'] == 'false')
+          sync_startup = !(ENV['NEW_RELIC_SYNC_STARTUP'].to_s.downcase == 'false')
 
           require 'newrelic_rpm'
           unless Rails.env.test?


### PR DESCRIPTION
Currently, app startup gives an ugly warning on New Relic initialization. This happens because the `manual_start` seems to be buggy. 

However, the New Relic behaviour on Rails is to call `init_plugin` (which `manual_start` eventually calls too). I think we should follow what New Relic does in its initialiser.

Additionally, the default behaviour in Rails is to set `sync_startup` to false, while `manual_start` sets it to true. I don't want to change the default behaviour here, as it could have unexpected consequences (very short lived processes would potentially not be able to send reports). However, we should allow apps to run with `sync_startup` set to false, in case startup time is important and the process is long-living. This allows setting the `NEW_RELIC_SYNC_STARTUP` environment variable (as per New Relic config), defaulting it to `true`.