### PR TITLE
Set log level after instantiating logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Features:
 
 Bug fix:
 
-- Set log level when instantiating logger; this avoids always outputting an initial "debug" line
+- Set log level when instantiating logger; this avoids always outputting an initial "debug" line (#89)
 
 # v1.19.0 (2018-01-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Features:
 
 - Add Hopper compatibility for DataDog integration (#90)
 
+Bug fix:
+
+- Set log level when instantiating logger; this avoids always outputting an initial "debug" line
+
 # v1.19.0 (2018-01-23)
 
 Bug fixes:

--- a/lib/roo_on_rails/logger.rb
+++ b/lib/roo_on_rails/logger.rb
@@ -40,6 +40,7 @@ module RooOnRails
         l.formatter = method(:_formatter)
       end
       super(logger)
+      set_log_level(default: Rails.configuration.log_level)
     end
 
     def with(context = {})

--- a/lib/roo_on_rails/logger.rb
+++ b/lib/roo_on_rails/logger.rb
@@ -40,7 +40,6 @@ module RooOnRails
         l.formatter = method(:_formatter)
       end
       super(logger)
-      set_log_level(default: Rails.configuration.log_level)
     end
 
     def with(context = {})

--- a/lib/roo_on_rails/railties/logging.rb
+++ b/lib/roo_on_rails/railties/logging.rb
@@ -15,6 +15,9 @@ module RooOnRails
       end
 
       initializer 'roo_on_rails.logging.after', after: :initialize_logger do
+        log_level = Rails.configuration.log_level
+
+        Rails.logger.set_log_level(default: log_level)
         Rails.logger.debug 'initializer roo_on_rails.logging.after'
       end
     end

--- a/lib/roo_on_rails/railties/logging.rb
+++ b/lib/roo_on_rails/railties/logging.rb
@@ -4,10 +4,6 @@ module RooOnRails
       initializer 'roo_on_rails.logging.before', before: :initialize_logger do
         require 'roo_on_rails/logger'
         Rails.logger = config.logger = RooOnRails::Logger.new
-        Rails.logger.debug 'initializer roo_on_rails.logging.before'
-      end
-
-      initializer 'roo_on_rails.logging.after', after: :initialize_logger do
         # It is not possible to set log_level to an invalid value without some
         # deliberate gymnastics (the setter will raise an error), and Rails
         # defaults this to `debug`, so we don't need to guard against nil /
@@ -15,6 +11,10 @@ module RooOnRails
         log_level = Rails.configuration.log_level
 
         Rails.logger.set_log_level(default: log_level)
+        Rails.logger.debug 'initializer roo_on_rails.logging.before'
+      end
+
+      initializer 'roo_on_rails.logging.after', after: :initialize_logger do
         Rails.logger.debug 'initializer roo_on_rails.logging.after'
       end
     end


### PR DESCRIPTION
The logger is instantiated before the "logging" ralitie which sets the level; this means that "debug" lines before logging is set would be output regardless of the set level. This fixes that.