### PR TITLE
NI-XXX: Add Hopper compatibility for DataDog integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HEAD
 
-_A description of your awesome changes here!_
+- Add Hopper compatibility for DataDog integration
 
 # v1.19.0 (2018-01-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # HEAD
 
-- Add Hopper compatibility for DataDog integration
-
-# v1.19.0 (2018-01-23)
-
-Bug fix:
-
-- Avoid New Relic initialization warning by following Rails initializer behaviour
+_A description of your awesome changes here!_
 
 Features:
 
-- Allow disabling New Relic synchronous startup by setting `NEW_RELIC_SYNC_STARTUP=false`
+- Add Hopper compatibility for DataDog integration (#90)
+
+# v1.19.0 (2018-01-23)
+
+Bug fixes:
+
+- Avoid New Relic initialization warning by following Rails initializer behaviour (#88)
+
+Features:
+
+- Allow disabling New Relic synchronous startup by setting `NEW_RELIC_SYNC_STARTUP=false` (#88)
 
 # v1.18.0 (2018-01-11)
 
@@ -27,14 +31,14 @@ Features:
 
 # v1.16.2 (2017-12-15)
 
-Bug fix:
+Bug fixes:
 
 - It's possible to set an invalid log level and crash on boot (#84)
 - Do not disable ActiveRecord connection reaping by default; set default behaviour to Rails' default behaviour. (#85)
 
 # v1.16.1 (2017-11-20)
 
-Bug fix:
+Bug fixes:
 
 - Auto-load roo identity if configured, prevent failing in CI (#83)
 
@@ -44,7 +48,7 @@ Features:
 
 - Allow SSL enforcement to be disabled via `ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT` environment variable (#82)
 
-Bug fix:
+Bug fixes:
 
 - Ensure we can distinguish between environments' identity services (#81)
 
@@ -63,7 +67,7 @@ Bug Fix:
 
 # v1.13.1 (2017-10-18)
 
-Bug fix:
+Bug fixes:
 
 - Fixes issue when `service_name` is null in `require_api_key` (#74)
 
@@ -74,7 +78,7 @@ Features:
 - Provide `ROUTEMASTER_VERIFY_SSL` environment variable to disable
   routemaster-client's SSL verification. (#68)
 
-Bug fix:
+Bug fixes:
 
 - Fixes issue with `fix` command of the service setup scripts for papertrail (#66)
 - Fixes issue with API authentication concern where service name was incorrect (#71)

--- a/README.md
+++ b/README.md
@@ -278,31 +278,29 @@ This is automatically configured when running `roo_on_rails harness`.
 
 #### Custom application metrics
 
-Sending custom metrics to Datadog through Statsd requires an agent running in
-each dyno.
-You need to add the buildpack
-[`heroku-buildpack-datadog`](https://github.com/deliveroo/heroku-buildpack-datadog).
+Sending custom metrics to Datadog through Statsd requires an agent running in each dyno or container. For Heroku you need to add the buildpack [`heroku-buildpack-datadog`](https://github.com/deliveroo/heroku-buildpack-datadog).
 
 Once this is done, you can send metrics with e.g.:
 
 ```ruby
-RooOnRails.statsd.increment('my.metric', tags: 'tag:value')
+RooOnRails.statsd.increment('my.metric', tags: ['tag:value'])
 ```
 
-Tags `env:{name}`, `source:{dyno}`, and `app:{name}` will automatically be added
-to all your metrics.
+The following tags will automatically be added to all your metrics and their value depends on the environment variables listed below, in order of priority:
 
-The following environment variables are being used.  The default values are fine
-except for `STATSD_ENV` which should be set.
-
-- `STATSD_ENV`
-- `STATSD_HOST`
-- `STATSD_PORT`
-
-These extra required variables are automatically set by Heroku:
-
-- `DYNO`
-- `HEROKU_APP_NAME`
+* `env:{name}`
+  * `STATDS_ENV` – optional and to be set manually (e.g. `staging`);
+  * `HOPPER_ECS_CLUSTER_NAME` – automatically set by Hopper (e.g. `staging`);
+  * Defaults to `unknown`.
+* `source:{name}`
+  * `DYNO` – automatically set by Heroku (e.g. `web.3`);
+  * `HOSTNAME` – automatically set by Hopper (e.g. `876c57c17207`);
+  * Defaults to `unknown`.
+* `app:{name}`
+  * `STATSD_APP_NAME` – optional and to be set manually (e.g. `notifications-staging`);
+  * `HEROKU_APP_NAME` – automatically set by Heroku (e.g. `roo-notifications-staging`);
+  * `HOPPER_APP_NAME`+`HOPPER_ECS_CLUSTER_NAME` – automatically set by Hopper (e.g. `notifications-staging`);
+  * Defaults to `unknown`.
 
 ### Routemaster Client
 

--- a/lib/roo_on_rails/statsd.rb
+++ b/lib/roo_on_rails/statsd.rb
@@ -34,7 +34,14 @@ module RooOnRails
     end
 
     def app_name
-      ENV['HEROKU_APP_NAME'] || ENV['STATSD_APP_NAME'] || 'unknown'
+      ENV['HEROKU_APP_NAME'] || ENV['STATSD_APP_NAME'] || hopper_app_name || 'unknown'
+    end
+
+    def hopper_app_name
+      app_name = ENV['HOPPER_APP_NAME']
+      cluster_name = ENV['HOPPER_ECS_CLUSTER_NAME']
+      return unless app_name && cluster_name
+      [app_name, cluster_name].join('-')
     end
   end
 

--- a/lib/roo_on_rails/statsd.rb
+++ b/lib/roo_on_rails/statsd.rb
@@ -23,10 +23,14 @@ module RooOnRails
 
     def tags
       [
-        "env:#{ENV.fetch('STATSD_ENV', 'unknown')}",
+        "env:#{env_name}",
         "source:#{source_name}",
         "app:#{app_name}"
       ]
+    end
+
+    def env_name
+      ENV['STATSD_ENV'] || ENV['HOPPER_ECS_CLUSTER_NAME'] || 'unknown'
     end
 
     def source_name
@@ -34,7 +38,7 @@ module RooOnRails
     end
 
     def app_name
-      ENV['HEROKU_APP_NAME'] || ENV['STATSD_APP_NAME'] || hopper_app_name || 'unknown'
+      ENV['STATSD_APP_NAME'] || ENV['HEROKU_APP_NAME'] || hopper_app_name || 'unknown'
     end
 
     def hopper_app_name

--- a/lib/roo_on_rails/statsd.rb
+++ b/lib/roo_on_rails/statsd.rb
@@ -25,8 +25,12 @@ module RooOnRails
       [
         "env:#{ENV.fetch('STATSD_ENV', 'unknown')}",
         "source:#{ENV.fetch('DYNO', 'unknown')}",
-        "app:#{ENV.fetch('HEROKU_APP_NAME', 'unknown')}"
+        "app:#{app_name}"
       ]
+    end
+
+    def app_name
+      ENV['HEROKU_APP_NAME'] || ENV['STATSD_APP_NAME'] || 'unknown'
     end
   end
 

--- a/lib/roo_on_rails/statsd.rb
+++ b/lib/roo_on_rails/statsd.rb
@@ -24,9 +24,13 @@ module RooOnRails
     def tags
       [
         "env:#{ENV.fetch('STATSD_ENV', 'unknown')}",
-        "source:#{ENV.fetch('DYNO', 'unknown')}",
+        "source:#{source_name}",
         "app:#{app_name}"
       ]
+    end
+
+    def source_name
+      ENV['DYNO'] || ENV['HOSTNAME'] || 'unknown'
     end
 
     def app_name


### PR DESCRIPTION
Currently the DataDog integration for custom app metrics relies on Heroku environment variables. This adds support for Hopper with an option to set the app name manually.