### PR TITLE
Updates Sidekiq Pro statsd integration syntax

### DIFF
--- a/lib/roo_on_rails/railties/sidekiq.rb
+++ b/lib/roo_on_rails/railties/sidekiq.rb
@@ -39,8 +39,16 @@ module RooOnRails
       end
 
       def config_sidekiq_metrics
+        # https://github.com/mperham/sidekiq/wiki/Pro-Metrics
         require 'sidekiq-pro'
         ::Sidekiq::Pro.dogstatsd = -> { RooOnRails.statsd }
+
+        Sidekiq.configure_server do |config|
+          config.server_middleware do |chain|
+            require 'sidekiq/middleware/server/statsd'
+            chain.add Sidekiq::Middleware::Server::Statsd
+          end
+        end
       rescue LoadError
         Rails.logger.warn 'Sidekiq metrics unavailable without Sidekiq Pro'
       end

--- a/lib/roo_on_rails/railties/sidekiq.rb
+++ b/lib/roo_on_rails/railties/sidekiq.rb
@@ -9,7 +9,7 @@ module RooOnRails
     class Sidekiq < Rails::Railtie
       initializer 'roo_on_rails.sidekiq' do |app|
         Rails.logger.with initializer: 'roo_on_rails.sidekiq' do |log|
-          
+
           unless RooOnRails::Config.sidekiq_enabled?
             log.debug 'skipping'
             next
@@ -17,7 +17,7 @@ module RooOnRails
 
           log.debug 'loading'
           require 'hirefire-resource'
-         
+
           config_sidekiq
           config_sidekiq_metrics
           config_hirefire(app)
@@ -40,13 +40,8 @@ module RooOnRails
       end
 
       def config_sidekiq_metrics
-        require 'sidekiq/middleware/server/statsd'
-
-        ::Sidekiq.configure_server do |x|
-          x.server_middleware do |chain|
-            chain.add ::Sidekiq::Middleware::Server::Statsd, client: RooOnRails.statsd
-          end
-        end
+        require 'sidekiq-pro'
+        ::Sidekiq::Pro.dogstatsd = -> { RooOnRails.statsd }
       rescue LoadError
         Rails.logger.warn 'Sidekiq metrics unavailable without Sidekiq Pro'
       end

--- a/lib/roo_on_rails/railties/sidekiq.rb
+++ b/lib/roo_on_rails/railties/sidekiq.rb
@@ -9,7 +9,6 @@ module RooOnRails
     class Sidekiq < Rails::Railtie
       initializer 'roo_on_rails.sidekiq' do |app|
         Rails.logger.with initializer: 'roo_on_rails.sidekiq' do |log|
-
           unless RooOnRails::Config.sidekiq_enabled?
             log.debug 'skipping'
             next


### PR DESCRIPTION
Newer versions of `sidekiq-pro` no longer take options when creating middleware. This change uses a Proc to set the dogstatsd instance as is the current style.