### PR TITLE
Support rails 5.2

### DIFF
--- a/lib/roo_on_rails/railties/http.rb
+++ b/lib/roo_on_rails/railties/http.rb
@@ -9,13 +9,13 @@ module RooOnRails
           require 'rack/ssl-enforcer'
           require 'roo_on_rails/rack/safe_timeouts'
 
-          ::Rack::Timeout.service_timeout = ENV.fetch('RACK_SERVICE_TIMEOUT', 15).to_i
-          ::Rack::Timeout.wait_timeout = ENV.fetch('RACK_WAIT_TIMEOUT', 30).to_i
           ::Rack::Timeout::Logger.level = ::Logger::WARN
 
           app.config.middleware.insert_before(
             ::Rack::Runtime,
-            ::Rack::Timeout
+            ::Rack::Timeout,
+            service_timeout: ENV.fetch('RACK_SERVICE_TIMEOUT', 15).to_i,
+            wait_timeout: ENV.fetch('RACK_WAIT_TIMEOUT', 30).to_i
           )
 
           middleware_to_insert_before = Rails::VERSION::MAJOR < 4 ? ::ActionDispatch::Cookies : ::Rack::Head

--- a/roo_on_rails.gemspec
+++ b/roo_on_rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rails', '>= 3.2.22', '< 5.3'
   spec.add_runtime_dependency 'platform-api', '~> 2.0'
   spec.add_runtime_dependency 'hashie', '~> 3.4'
-  spec.add_runtime_dependency 'rack-timeout'
+  spec.add_runtime_dependency 'rack-timeout', '>= 0.4.0'
   spec.add_runtime_dependency 'rack-ssl-enforcer'
   spec.add_runtime_dependency 'octokit'
   spec.add_runtime_dependency 'hirefire-resource'


### PR DESCRIPTION
* Fix `Rack::Timeout` compatibility issue. Require `Rack::Timeout` >= 0.4.0.
