### PR TITLE
LOG-3076: Report to New Relic per Hopper service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.22.0 (2018-08-29)
+
+Features:
+
+ - Allows specifiying `BASE_NEW_RELIC_APP_NAME` instead of `NEW_RELIC_APP_NAME`, which reports to New Relic per Hopper service.
+
 # v1.21.0 (2018-03-27)
 
 Features:

--- a/lib/roo_on_rails/railties/new_relic.rb
+++ b/lib/roo_on_rails/railties/new_relic.rb
@@ -12,6 +12,15 @@ module RooOnRails
 
           abort 'Aborting: NEW_RELIC_LICENSE_KEY is required' if license_key.nil?
 
+          # Report application stats to a per-service (worker, web) New Relic app, and to a main
+          # application for all services.
+          base_name = ENV['BASE_NEW_RELIC_APP_NAME']
+          service_name = ENV['HOPPER_SERVICE_NAME']
+          if !base_name.blank? && ENV['NEW_RELIC_APP_NAME'].blank?
+            task_app_name = service_name.present? ? "#{base_name} - #{service_name}" : nil
+            ENV['NEW_RELIC_APP_NAME'] = [task_app_name, base_name].compact.join(';')
+          end
+
           path = %w(newrelic.yml config/newrelic.yml).map do |p|
             Pathname.new(p)
           end.find(&:exist?)

--- a/lib/roo_on_rails/version.rb
+++ b/lib/roo_on_rails/version.rb
@@ -1,3 +1,3 @@
 module RooOnRails
-  VERSION = '1.21.0'.freeze
+  VERSION = '1.22.0'.freeze
 end

--- a/spec/integration/new_relic_spec.rb
+++ b/spec/integration/new_relic_spec.rb
@@ -64,6 +64,45 @@ describe 'New Relic integration' do
     end
   end
 
+  context 'when BASE_NEW_RELIC_APP_NAME is set' do
+    let(:base_name) { 'base' }
+    let(:service_name) { 'service' }
+    let(:app_name) { nil }
+
+    let(:app_env_vars) do
+      [
+        super(),
+        "BASE_NEW_RELIC_APP_NAME=#{base_name}",
+        "HOPPER_SERVICE_NAME=#{service_name}",
+        "NEW_RELIC_APP_NAME=#{app_name}"
+      ].join("\n")
+    end
+
+    after { app.stop }
+
+    it 'uses HOPPER_SERVICE_NAME' do
+      app.wait_start
+      expect(app).to have_log /NewRelic.*Application: base - service, base/
+    end
+
+    context 'and NEW_RELIC_APP_NAME is set' do
+      let(:app_name) { 'specific' }
+
+      it 'uses NEW_RELIC_APP_NAME unmodified' do
+        app.wait_start
+        expect(app).to have_log /NewRelic.*Application: specific/
+      end
+    end
+
+    context 'and HOPPER_SERVICE_NAME is not set' do
+      let(:service_name) { nil }
+
+      it 'uses just the base name' do
+        app.wait_start
+        expect(app).to have_log /NewRelic.*Application: base/
+      end
+    end
+  end
 
   context 'when a newrelic.yml exists' do
     %w[. ./config].each do |path|


### PR DESCRIPTION
If `BASE_NEW_RELIC_APP_NAME` is set, report to New Relic for each Hopper
service individually *and* report everything to one central New Relic
application. If `NEW_RELIC_APP_NAME` is specified, report to one New
Relic application as before.

The Reliability Monitor requires that each web/worker service reports to
New Relic separately in order to get statistics about request
counts/errors.