### PR TITLE
SRE-1005: Add option to disable `statement_timeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
+# v1.23.0 (2019-04-24)
+
+Features:
+
+- Setting DATABASE_STATEMENT_TIMEOUT to -1 will prevent the app setting any timeout.
+  Setting timeouts from the app conflicts with PGBouncer and should be disabled if
+  using one.
+
 # v1.22.0 (2018-08-29)
 
 Features:
 
- - Allows specifiying `BASE_NEW_RELIC_APP_NAME` instead of `NEW_RELIC_APP_NAME`, which reports to New Relic per Hopper service.
+ - Allows specifying `BASE_NEW_RELIC_APP_NAME` instead of `NEW_RELIC_APP_NAME`, which reports to New Relic per Hopper service.
 
 # v1.21.0 (2018-03-27)
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ To do this, you can set the `ROO_ON_RAILS_DISABLE_SSL_ENFORCEMENT` to `YES`.
 The database statement timeout will be set to a low value by default. Use
 `DATABASE_STATEMENT_TIMEOUT` (milliseconds, default 200) to customise.
 
+When using a PGBouncer, setting the timeout from the application will cause
+inconsistent results. The timeout should always be set using the RDS parameter
+group in thise case. To prevent the app trying to set a timeout, set
+`DATABASE_STATEMENT_TIMEOUT` to -1.
+
 For database creation and migration (specifically the `db:create`, `db:migrate`,
 `db:migrate:down` and `db:rollback` tasks) a much higher statement timeout is
 set by default. Use `MIGRATION_STATEMENT_TIMEOUT` (milliseconds, default 10000)

--- a/lib/roo_on_rails/railties/database.rb
+++ b/lib/roo_on_rails/railties/database.rb
@@ -8,11 +8,14 @@ module RooOnRails
 
             config = ActiveRecord::Base.configurations[Rails.env]
             config['variables'] ||= {}
-            config['variables']['statement_timeout'] = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', 200)
+            statement_timeout = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', 200)
+            # Use -1 to disable setting the statement timeout
+            unless statement_timeout == -1
+              config['variables']['statement_timeout'] = statement_timeout
+            end
             if ENV.key?('DATABASE_REAPING_FREQUENCY')
               config['reaping_frequency'] = ENV['DATABASE_REAPING_FREQUENCY']
             end
-
             ActiveRecord::Base.establish_connection
           end
         end

--- a/lib/roo_on_rails/railties/database.rb
+++ b/lib/roo_on_rails/railties/database.rb
@@ -10,7 +10,7 @@ module RooOnRails
             config['variables'] ||= {}
             statement_timeout = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', 200)
             # Use -1 to disable setting the statement timeout
-            unless statement_timeout == -1
+            unless statement_timeout == '-1'
               config['variables']['statement_timeout'] = statement_timeout
             end
             if ENV.key?('DATABASE_REAPING_FREQUENCY')

--- a/lib/roo_on_rails/version.rb
+++ b/lib/roo_on_rails/version.rb
@@ -1,3 +1,3 @@
 module RooOnRails
-  VERSION = '1.22.0'.freeze
+  VERSION = '1.23.0'.freeze
 end

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -31,6 +31,15 @@ describe 'Database setup', rails_min_version: 4 do
         end
       end
 
+      context 'when DATABASE_STATEMENT_TIMEOUT is -1' do
+        before { ENV['DATABASE_STATEMENT_TIMEOUT'] = '-1' }
+        after { ENV['DATABASE_STATEMENT_TIMEOUT'] = nil }
+
+        it 'does not set a statement timeout' do
+          expect(statement_timeout).to_not include '200ms'
+        end
+      end
+
       context 'when DATABASE_STATEMENT_TIMEOUT is set' do
         before { ENV['DATABASE_STATEMENT_TIMEOUT'] = '750' }
         after { ENV['DATABASE_STATEMENT_TIMEOUT'] = nil }


### PR DESCRIPTION
Setting `DATABASE_STATEMENT_TIMEOUT` variable to `-1` will now prevent enforcing a `statement_timeout` in the DB config. The previous behaviour conflicts with PGBouncer and cannot be disabled.