### PR TITLE
[PROD-637] Remove Hirefire gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@
     - [Disabling SSL enforcement](#disabling-ssl-enforcement)
   - [Database configuration](#database-configuration)
   - [Sidekiq](#sidekiq)
-  - [HireFire](#hirefire)
-    - [For Web Dynos](#for-web-dynos)
-    - [For Sidekiq Workers](#for-sidekiq-workers)
   - [Logging](#logging)
   - [Identity](#identity)
   - [Google OAuth authentication](#google-oauth-authentication)
@@ -136,48 +133,6 @@ The following ENV are available:
 NB. If you are migrating to SLA-based queue names, do not set `SIDEKIQ_ENABLED`
 to `true` before your old queues have finished processing (this will prevent
 Sidekiq from seeing the old queues at all).
-
-### HireFire
-
-#### For Web Dynos
-
-Web dynos can be autoscaled by HireFire _only_ if it has been configured to use the `Web.Logplex.Load` source and the Heroku runtime metrics lab feature has been enabled:
-
-```bash
-$ heroku labs:enable log-runtime-metrics -a your-service-name-here
-```
-
-You will also need a log drain for HireFire, but the RooOnRails helper below should configure this for you. You can check with
-
-```bash
-$ heroku drains | grep hirefire
-https://logdrain.hirefire.io (d.00000000-0000-0000-0000-000000000000)
-
-# No drain? Add with:
-$ heroku drains:add -a your-service-name-here https://logdrain.hirefire.io
-```
-
-([HireFire docs for set up](https://help.hirefire.io/guides/logplex/load-logplex))
-
-#### For Sidekiq Workers
-
-When `HIREFIRE_TOKEN` is set an endpoint will be mounted at `/hirefire` that
-reports the required worker count as a function of queue latency. By default we
-add queue names in the style 'within1day', so if we notice an average latency in
-that queue of more than an set threshold we'll request one more worker. If we
-notice less than a threshold we'll request one less worker. These settings can
-be customised via the following ENV variables
-
-- `WORKER_INCREASE_THRESHOLD` (default 0.5)
-- `WORKER_DECREASE_THRESHOLD` (default 0.1)
-
-When setting the manager up in the HireFire web ui, the following settings must
-be used:
-
-- name: 'worker'
-- type: 'Worker.HireFire.JobQueue'
-- ratio: 1
-- decrementable: 'true'
 
 ### Logging
 

--- a/lib/roo_on_rails/railties/sidekiq_integration.rb
+++ b/lib/roo_on_rails/railties/sidekiq_integration.rb
@@ -14,19 +14,9 @@ module RooOnRails
         end
 
         Rails.logger.debug '[roo_on_rails.sidekiq] loading'
-        require 'hirefire-resource'
 
         config_sidekiq
         config_sidekiq_metrics
-        config_hirefire(app)
-      end
-
-      def config_hirefire(app)
-        unless ENV['HIREFIRE_TOKEN']
-          Rails.logger.warn 'No HIREFIRE_TOKEN token set, auto scaling not enabled'
-          return
-        end
-        add_middleware(app)
       end
 
       def config_sidekiq

--- a/lib/roo_on_rails/version.rb
+++ b/lib/roo_on_rails/version.rb
@@ -1,3 +1,3 @@
 module RooOnRails
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end

--- a/roo_on_rails.gemspec
+++ b/roo_on_rails.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rack-timeout', '>= 0.4.0'
   spec.add_runtime_dependency 'rack-ssl-enforcer'
   spec.add_runtime_dependency 'octokit'
-  spec.add_runtime_dependency 'hirefire-resource'
   spec.add_runtime_dependency 'sidekiq', '< 6.0.0'
   spec.add_runtime_dependency 'dogstatsd-ruby'
   spec.add_runtime_dependency 'omniauth-google-oauth2'

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -1,26 +1,6 @@
 require 'spec_helper'
 require 'spec/support/run_test_app'
 
-describe 'Sidekiq Setup' do
-  run_test_app
-  before { app.wait_start }
-
-  context 'When booting' do
-    let(:middleware) { app_helper.shell_run "cd #{app_path} && rake middleware" }
-    it 'does not insert hirefire into the middleware stack' do
-      expect(middleware).not_to include 'HireFire::Middleware'
-    end
-
-    context "if HIREFIRE_TOKEN is set" do
-      let(:app_env_vars) { ["HIREFIRE_TOKEN=hello", super()].join("\n") }
-
-      it 'inserts hirefire into the middleware stack' do
-        expect(middleware).to include 'HireFire::Middleware'
-      end
-    end
-  end
-end
-
 describe "sidekiq loader" do
   run_sidekiq
   before { app.wait_start }


### PR DESCRIPTION
# [PROD-637](https://deliveroo.atlassian.net/browse/PROD-637)

Removes Hirefire gem, which was a dependency of Heroku, a PaaS we no longer use