### PR TITLE
Fix env from jwt bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.1.2
+
+Bug fix:
+
+- fixes PopulateEnvFromJWT caching issue where a key that couldn't be fetched would be cached
+
 # v2.1.0
 
 Features:

--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ The command is designed to fix issues in many cases.
 Pull requests are welcome on GitHub at
 `https://github.com/deliveroo/roo_on_rails`.
 
+## Releasing
+
+1. Bump the version number in `lib/roo_on_rails/version.rb
+1. Add an entry to the changelog
+1. After merging to master release e.g. `bundle exec rake release`
 
 ## License
 

--- a/lib/roo_on_rails/rack/populate_env_from_jwt.rb
+++ b/lib/roo_on_rails/rack/populate_env_from_jwt.rb
@@ -22,7 +22,8 @@ module RooOnRails
         @app = app
         @logger = logger
         @url_mappings = url_mappings
-        @keys = @mapped_urls = {}
+        @keys = {}
+        @mapped_urls = {}
 
         if skip_sig_verify && non_prod?
           @logger.warn "JWTs signature verifification has been switched off in development."

--- a/lib/roo_on_rails/version.rb
+++ b/lib/roo_on_rails/version.rb
@@ -1,3 +1,3 @@
 module RooOnRails
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.2'.freeze
 end

--- a/spec/roo_on_rails/rack/populate_env_from_jwt_spec.rb
+++ b/spec/roo_on_rails/rack/populate_env_from_jwt_spec.rb
@@ -179,5 +179,21 @@ describe RooOnRails::Rack::PopulateEnvFromJWT, :webmock do
 
       its(:status) { should eq 401 }
     end
+
+    context 'when url is mapped and key fetching fails' do
+      let(:unmapped_prefix) { 'https://deliveroo.co.uk/' }
+      let(:mapped_prefix) { 'http://direct.url/' }
+      let(:jku) { unmapped_prefix + 'identity-keys/0.jwk' }
+      let(:url_mappings) { { unmapped_prefix => mapped_prefix } }
+
+      before { stub_request(:get, mapped_prefix + 'identity-keys/0.jwk').to_return( {status: 404}, {body: TEST_JWK_PUB}) }
+
+      it 'works the second time' do
+        expect { subject }.to raise_error(Faraday::ResourceNotFound)
+        subject
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
keys and mapped_urls were sharing the same dictionary.

During normal use this doesn't seem to break anything. But if the first call to get a key fails - then we will cache the mapped url in the keys dictionary. Then try and use this URL as a key object, this fails.