### PR TITLE
Fix frozen config issue in 6.1

### DIFF
--- a/lib/roo_on_rails/railties/database.rb
+++ b/lib/roo_on_rails/railties/database.rb
@@ -3,18 +3,29 @@ module RooOnRails
     class Database < Rails::Railtie
       initializer 'roo_on_rails.database', after: 'active_record.initialize_database' do
         ActiveSupport.on_load :active_record do
-          Rails.logger.debug('[roo_on_rails.database] loading')
+          statement_timeout = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', nil)
+          reaping_frequency = ENV.fetch('DATABASE_REAPING_FREQUENCY', nil)
 
-          config = ActiveRecord::Base.configurations[Rails.env]
-          config['variables'] ||= {}
-          statement_timeout = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', 200)
-          # Use -1 to disable setting the statement timeout
-          unless statement_timeout == '-1'
-            config['variables']['statement_timeout'] = statement_timeout
+          if Rails.version.to_f >= 6.1
+            # The config is frozen in 6.1 and will error. In 7.x the config
+            # is changed from a Hash to HashConfig which has no setter
+            # methods. Rails intend you to not modify the config outside of
+            # the environment/*.yml files.
+            Rails.logger.warn('[roo_on_rails.database] DATABASE_STATEMENT_TIMEOUT is not set') unless statement_timeout
+          else
+            Rails.logger.debug('[roo_on_rails.database] loading')
+
+            config = ActiveRecord::Base.configurations[Rails.env]
+            config['variables'] ||= {}
+
+            # Use -1 to disable setting the statement timeout
+            unless statement_timeout == '-1'
+              config['variables']['statement_timeout'] = statement_timeout || 200
+            end
+
+            config['reaping_frequency'] = reaping_frequency if reaping_frequency
           end
-          if ENV.key?('DATABASE_REAPING_FREQUENCY')
-            config['reaping_frequency'] = ENV['DATABASE_REAPING_FREQUENCY']
-          end
+
           ActiveRecord::Base.establish_connection
         end
       end

--- a/lib/roo_on_rails/tasks/db.rake
+++ b/lib/roo_on_rails/tasks/db.rake
@@ -8,7 +8,7 @@ if defined?(ActiveRecord)
 
     namespace :migrate do
       task extend_statement_timeout: :environment do
-        if ActiveRecord::VERSION::MAJOR >= 4
+        if Rails.version.to_f < 6.1
           config = ActiveRecord::Base.configurations[Rails.env]
           config['variables'] ||= {}
           config['variables']['statement_timeout'] = ENV.fetch('MIGRATION_STATEMENT_TIMEOUT', 10_000)

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -26,6 +26,10 @@ describe 'Database setup', rails_min_version: 4 do
       let(:statement_timeout) { app_helper.shell_run "cd #{app_path} && rake db:statement_timeout" }
 
       context 'when DATABASE_STATEMENT_TIMEOUT is not set' do
+        around(:example) do |example|
+          example.skip if Rails.version.to_f >= 6.1
+        end
+
         it 'sets the statement timeout to 200ms' do
           expect(statement_timeout).to include '200ms'
         end
@@ -35,6 +39,10 @@ describe 'Database setup', rails_min_version: 4 do
         before { ENV['DATABASE_STATEMENT_TIMEOUT'] = '-1' }
         after { ENV['DATABASE_STATEMENT_TIMEOUT'] = nil }
 
+        around(:example) do |example|
+          example.skip if Rails.version.to_f >= 6.1
+        end
+
         it 'does not set a statement timeout' do
           expect(statement_timeout).to_not include '200ms'
         end
@@ -43,6 +51,10 @@ describe 'Database setup', rails_min_version: 4 do
       context 'when DATABASE_STATEMENT_TIMEOUT is set' do
         before { ENV['DATABASE_STATEMENT_TIMEOUT'] = '750' }
         after { ENV['DATABASE_STATEMENT_TIMEOUT'] = nil }
+
+        around(:example) do |example|
+          example.skip if Rails.version.to_f >= 6.1
+        end
 
         it 'sets the statement timeout to the value in ms' do
           expect(statement_timeout).to include '750ms'

--- a/spec/integration/google_auth_spec.rb
+++ b/spec/integration/google_auth_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe 'Google OAuth' do
   end
 
   describe 'routes' do
-    let(:output) { app_helper.shell_run "cd #{app_path} && rake routes" }
+    let(:output) do
+      command = Rails.version.to_f >= 6.1 ? 'rails routes' : 'rake routes'
+      app_helper.shell_run "cd #{app_path} && #{command}"
+    end
 
     context "if Google Auth has been enabled" do
       before { ENV['GOOGLE_AUTH_ENABLED'] = 'YES' }


### PR DESCRIPTION
The config is frozen in 6.1 and is changed entirely to a HashConfig in 7.x. We are not supposed to modify the config like this anymore and we should stop doing it.

When people upgrade to the latest gem version using Rails 6.1 or greater they will see a warning in the console to set this variable themselves unless it is already set.